### PR TITLE
[feat] 50/communitylist 화면 생성

### DIFF
--- a/lib/community/community.md
+++ b/lib/community/community.md
@@ -1,0 +1,43 @@
+아래 내 요구사항을 반영해서 코드를 다시 작성해줘.
+
+1.  dataSource에서 sort파라미터를 받지 않고 모든 postList를 제공하는 메소드로 수정해줘.
+2.  PostDto도 freezed 3.0.6 버전을 이용해서 작성해줘.
+3.  id는 int 말고 String 타입으로 만들어줘.
+4.  내가 사용할 모델인 Post의 필드값들은 아래와 같아. 필요한 필드값이 있다면 더 추가해줘도 돼.
+    id, String
+    title, String
+    content, String
+    member, <Member>
+    boardType, enum
+    createdAt, DateTime
+    hashTag, List<HashTag>
+    like, List<Like>
+5.  RepositoryImpl의 필드값에는 외부에서 주입해주는 DataSource가 존재해. 유즈케이스에서는 내가 말한대로 만들어준거같은데, namedParameter를 이용하면 더 좋을거같아.
+6.  내가 다루는 CommunityListState의 필드값에 AsyncValue가 들어가면 Notifier파일에서 asyncNotifier 보다 notifier를 사용해서 구현하는게 더 섬세한 부분을 커버해줄거 같은데, 만약 내말이 맞다면 그렇게 구현해줘.
+
+
+
+아래 내 요구사항을 반영해서 코드를 다시 작성해줘.
+1. DTO는 nullable하게 구현하는게 좋을거같아.
+2. DTO에 있는 Member 필드는 lib/auth를 담당하고있는 다른 사람이 작성하고있어서 내가 작성하면 안될것같아. 일단 목데이터같은걸로 사용할 수 있게 구현해줘. Member모델에는 id, email, nickname, uid, onAir, image 필드가 존재해.
+3. 내가 담당해서 만들 모델들인 Like, Comment, HashTag모델에서 다루는 필드값은 아래와 같아.
+   Table Like {
+   boardId, String, , ;
+   memberId, String, , ;
+   }
+   Table Comment {
+   boardId, String, , ;
+   memberId, String, , ;
+   createdAt, DateTime, , ;
+   content, String, , ;
+   }
+   Table HashTag {
+   id, String, , ;
+   content, String, , ;
+   }
+4. import할때 경로는 가능한 package:로 시작하는 절대경로로 작성해줘.
+5. presentation에 만든 action, state등의 파일들은 presentation/community_list 폴더로 이동시켜줘. 나중에 community_detail등 다른 폴더도 만들거거든.
+
+아래 내 요구사항을 반영해서 코드를 다시 작성해줘.
+1. 일단 내가 사용할 Member 모델도 만들어줘.
+2. 내가 사용할 enum들은 module/util에 dart파일로 따로따로 만들어줘.

--- a/lib/community/community_main.dart
+++ b/lib/community/community_main.dart
@@ -1,0 +1,21 @@
+import 'package:devlink_mobile_app/community/module/community_router.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  runApp(const ProviderScope(child: MyApp()));
+}
+
+class MyApp extends ConsumerWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(communityRouterProvider);
+    return MaterialApp.router(
+      title: '커뮤니티 스크린',
+      routerConfig: router,
+      theme: ThemeData(),
+    );
+  }
+}

--- a/lib/community/data/data_source/mock_post_data_source_impl.dart
+++ b/lib/community/data/data_source/mock_post_data_source_impl.dart
@@ -1,0 +1,43 @@
+// lib/community/data/data_source/post_data_source_impl.dart
+import 'dart:math';
+import 'package:devlink_mobile_app/community/data/dto/hash_tag_dto.dart';
+import 'package:devlink_mobile_app/community/data/dto/like_dto.dart';
+import 'package:devlink_mobile_app/community/data/dto/member_dto.dart';
+import 'package:devlink_mobile_app/community/data/dto/post_dto.dart';
+
+import 'post_data_source.dart';
+
+class PostDataSourceImpl implements PostDataSource {
+  @override
+  Future<List<PostDto>> fetchPostList() async {
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    final rand = Random();
+
+    return List.generate(30, (i) {
+      final likeCnt = rand.nextInt(200);
+      return PostDto(
+        id: 'post_$i',
+        title: '목 게시글 $i',
+        content: '[Mock] 내용 $i',
+        member: MemberDto(            // auth 완성 전까지 임시
+          id: 'u$i',
+          email: 'user$i@mail.com',
+          nickname: 'user$i',
+          uid: 'uid_$i',
+          onAir: i.isEven,
+          image: '',
+        ),
+        boardType: BoardType.free,
+        createdAt: DateTime.now().subtract(Duration(minutes: i * 5)),
+        hashTag: [
+          HashTagDto(id: 't1', content: '#태그${i % 3}'),
+          if (i.isEven) HashTagDto(id: 't2', content: '#인기'),
+        ],
+        like: List.generate(
+          likeCnt,
+          (idx) => LikeDto(boardId: 'post_$i', memberId: 'u$idx'),
+        ),
+      );
+    });
+  }
+}

--- a/lib/community/data/data_source/mock_post_data_source_impl.dart
+++ b/lib/community/data/data_source/mock_post_data_source_impl.dart
@@ -4,6 +4,7 @@ import 'package:devlink_mobile_app/community/data/dto/hash_tag_dto.dart';
 import 'package:devlink_mobile_app/community/data/dto/like_dto.dart';
 import 'package:devlink_mobile_app/community/data/dto/member_dto.dart';
 import 'package:devlink_mobile_app/community/data/dto/post_dto.dart';
+import 'package:devlink_mobile_app/community/module/util/board_type_enum.dart';
 
 import 'post_data_source.dart';
 

--- a/lib/community/data/data_source/post_data_source.dart
+++ b/lib/community/data/data_source/post_data_source.dart
@@ -1,0 +1,7 @@
+// lib/community/data/data_source/post_data_source.dart
+import 'package:devlink_mobile_app/community/data/dto/post_dto.dart';
+
+abstract interface class PostDataSource {
+  /// 모든 게시글을 한 번에 가져온다.
+  Future<List<PostDto>> fetchPostList();
+}

--- a/lib/community/data/dto/comment_dto.dart
+++ b/lib/community/data/dto/comment_dto.dart
@@ -2,7 +2,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 part 'comment_dto.freezed.dart';
 part 'comment_dto.g.dart';
-
 @freezed
 abstract class CommentDto with _$CommentDto {
   const factory CommentDto({

--- a/lib/community/data/dto/commnet_dto.dart
+++ b/lib/community/data/dto/commnet_dto.dart
@@ -1,0 +1,17 @@
+// lib/community/data/dto/comment_dto.dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'comment_dto.freezed.dart';
+part 'comment_dto.g.dart';
+
+@freezed
+abstract class CommentDto with _$CommentDto {
+  const factory CommentDto({
+    String?   boardId,
+    String?   memberId,
+    DateTime? createdAt,
+    String?   content,
+  }) = _CommentDto;
+
+  factory CommentDto.fromJson(Map<String, dynamic> json) =>
+      _$CommentDtoFromJson(json);
+}

--- a/lib/community/data/dto/hash_tag_dto.dart
+++ b/lib/community/data/dto/hash_tag_dto.dart
@@ -1,0 +1,15 @@
+// lib/community/data/dto/hash_tag_dto.dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'hash_tag_dto.freezed.dart';
+part 'hash_tag_dto.g.dart';
+
+@freezed
+abstract class HashTagDto with _$HashTagDto {
+  const factory HashTagDto({
+    String? id,
+    String? content,
+  }) = _HashTagDto;
+
+  factory HashTagDto.fromJson(Map<String, dynamic> json) =>
+      _$HashTagDtoFromJson(json);
+}

--- a/lib/community/data/dto/like_dto.dart
+++ b/lib/community/data/dto/like_dto.dart
@@ -1,0 +1,15 @@
+// lib/community/data/dto/like_dto.dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'like_dto.freezed.dart';
+part 'like_dto.g.dart';
+
+@freezed
+abstract class LikeDto with _$LikeDto {
+  const factory LikeDto({
+    String? boardId,
+    String? memberId,
+  }) = _LikeDto;
+
+  factory LikeDto.fromJson(Map<String, dynamic> json) =>
+      _$LikeDtoFromJson(json);
+}

--- a/lib/community/data/dto/member_dto.dart
+++ b/lib/community/data/dto/member_dto.dart
@@ -1,0 +1,20 @@
+// lib/community/data/dto/member_dto.dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'member_dto.freezed.dart';
+part 'member_dto.g.dart';
+
+/// 실제 Member 모델은 auth 모듈에서 교체 예정!
+@freezed
+abstract class MemberDto with _$MemberDto {
+  const factory MemberDto({
+    String? id,
+    String? email,
+    String? nickname,
+    String? uid,
+    bool?   onAir,
+    String? image,
+  }) = _MemberDto;
+
+  factory MemberDto.fromJson(Map<String, dynamic> json) =>
+      _$MemberDtoFromJson(json);
+}

--- a/lib/community/data/dto/post_dto.dart
+++ b/lib/community/data/dto/post_dto.dart
@@ -1,0 +1,29 @@
+// lib/community/data/dto/post_dto.dart
+import 'package:devlink_mobile_app/community/data/dto/hash_tag_dto.dart';
+import 'package:devlink_mobile_app/community/data/dto/like_dto.dart';
+import 'package:devlink_mobile_app/community/data/dto/member_dto.dart';
+import 'package:devlink_mobile_app/community/module/util/board_type_enum.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+
+part 'post_dto.freezed.dart';
+part 'post_dto.g.dart';
+
+/// 게시글 DTO (모든 필드 nullable)
+@freezed
+abstract class PostDto with _$PostDto {
+  const factory PostDto({
+    String? id,
+    String? title,
+    String? content,
+    MemberDto? member,               // 👉 auth 완성 전까지 임시 DTO
+    BoardType? boardType,
+    DateTime? createdAt,
+    List<HashTagDto>? hashTag,
+    List<LikeDto>? like,
+  }) = _PostDto;
+
+  factory PostDto.fromJson(Map<String, dynamic> json) =>
+      _$PostDtoFromJson(json);
+}
+

--- a/lib/community/data/mapper/post_mapper.dart
+++ b/lib/community/data/mapper/post_mapper.dart
@@ -1,0 +1,46 @@
+// lib/community/data/mapper/post_mapper.dart
+// import 'package:auth/domain/model/member.dart';
+import 'package:devlink_mobile_app/community/data/dto/hash_tag_dto.dart';
+import 'package:devlink_mobile_app/community/data/dto/like_dto.dart';
+import 'package:devlink_mobile_app/community/data/dto/member_dto.dart';
+import 'package:devlink_mobile_app/community/data/dto/post_dto.dart';
+import 'package:devlink_mobile_app/community/domain/model/hash_tag.dart';
+import 'package:devlink_mobile_app/community/domain/model/like.dart';
+import 'package:devlink_mobile_app/community/domain/model/post.dart';
+
+extension PostDtoMapper on PostDto {
+  Post toModel() => Post(
+        id: id ?? '',
+        title: title ?? '',
+        content: content ?? '',
+        member: member?.toModel() ??
+            Member(id: '', email: '', nickname: '', uid: '', onAir: false, image: ''),
+        boardType: boardType ?? BoardType.free,
+        createdAt: createdAt ?? DateTime.now(),
+        hashTag: (hashTag ?? []).map((e) => e.toModel()).toList(),
+        like: (like ?? []).map((e) => e.toModel()).toList(),
+      );
+}
+
+extension on MemberDto {
+  Member toModel() => Member(
+        id: id ?? '',
+        email: email ?? '',
+        nickname: nickname ?? '',
+        uid: uid ?? '',
+        onAir: onAir ?? false,
+        image: image ?? '',
+      );
+}
+
+extension on HashTagDto {
+  HashTag toModel() => HashTag(id: id ?? '', content: content ?? '');
+}
+
+extension on LikeDto {
+  Like toModel() => Like(boardId: boardId ?? '', memberId: memberId ?? '');
+}
+
+extension PostDtoListX on List<PostDto> {
+  List<Post> toModelList() => map((e) => e.toModel()).toList();
+}

--- a/lib/community/data/mapper/post_mapper.dart
+++ b/lib/community/data/mapper/post_mapper.dart
@@ -1,5 +1,6 @@
 // lib/community/data/mapper/post_mapper.dart
 // import 'package:auth/domain/model/member.dart';
+import 'package:devlink_mobile_app/auth/domain/model/member.dart';
 import 'package:devlink_mobile_app/community/data/dto/hash_tag_dto.dart';
 import 'package:devlink_mobile_app/community/data/dto/like_dto.dart';
 import 'package:devlink_mobile_app/community/data/dto/member_dto.dart';
@@ -7,6 +8,7 @@ import 'package:devlink_mobile_app/community/data/dto/post_dto.dart';
 import 'package:devlink_mobile_app/community/domain/model/hash_tag.dart';
 import 'package:devlink_mobile_app/community/domain/model/like.dart';
 import 'package:devlink_mobile_app/community/domain/model/post.dart';
+import 'package:devlink_mobile_app/community/module/util/board_type_enum.dart';
 
 extension PostDtoMapper on PostDto {
   Post toModel() => Post(

--- a/lib/community/data/repository_impl/post_repository_impl.dart
+++ b/lib/community/data/repository_impl/post_repository_impl.dart
@@ -1,0 +1,23 @@
+// lib/community/data/repository_impl/post_repository_impl.dart
+import 'package:devlink_mobile_app/community/data/data_source/post_data_source.dart';
+import 'package:devlink_mobile_app/community/data/mapper/post_mapper.dart';
+import 'package:devlink_mobile_app/community/domain/model/post.dart';
+import 'package:devlink_mobile_app/community/domain/repository/post_repository.dart';
+import 'package:devlink_mobile_app/core/result/result.dart';
+
+
+class PostRepositoryImpl implements PostRepository {
+  const PostRepositoryImpl({required PostDataSource dataSource}) : _remote = dataSource;
+
+  final PostDataSource _remote;
+
+  @override
+  Future<Result<List<Post>>> loadPostList() async {
+    try {
+      final dto = await _remote.fetchPostList();
+      return Result.success(dto.toModelList());
+    } catch (e) {
+      return Result.error(mapExceptionToFailure(e, StackTrace.fromString(e.toString())));
+    }
+  }
+}

--- a/lib/community/domain/model/comment.dart
+++ b/lib/community/domain/model/comment.dart
@@ -1,0 +1,13 @@
+// lib/community/domain/model/comment.dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'comment.freezed.dart';
+
+@freezed
+abstract class Comment with _$Comment {
+  const factory Comment({
+    required String boardId,
+    required String memberId,
+    required DateTime createdAt,
+    required String content,
+  }) = _Comment;
+}

--- a/lib/community/domain/model/hash_tag.dart
+++ b/lib/community/domain/model/hash_tag.dart
@@ -1,0 +1,11 @@
+// lib/community/domain/model/hash_tag.dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'hash_tag.freezed.dart';
+
+@freezed
+abstract class HashTag with _$HashTag {
+  const factory HashTag({
+    required String id,
+    required String content,
+  }) = _HashTag;
+}

--- a/lib/community/domain/model/like.dart
+++ b/lib/community/domain/model/like.dart
@@ -1,0 +1,11 @@
+// lib/community/domain/model/like.dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'like.freezed.dart';
+
+@freezed
+abstract class Like with _$Like {
+  const factory Like({
+    required String boardId,
+    required String memberId,
+  }) = _Like;
+}

--- a/lib/community/domain/model/post.dart
+++ b/lib/community/domain/model/post.dart
@@ -1,0 +1,25 @@
+// lib/community/domain/model/post.dart
+import 'package:devlink_mobile_app/community/domain/model/hash_tag.dart';
+import 'package:devlink_mobile_app/community/domain/model/like.dart';
+import 'package:devlink_mobile_app/community/module/util/board_type_enum.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+
+
+part 'post.freezed.dart';
+
+@freezed
+abstract class Post with _$Post {
+  const factory Post({
+    required String id,
+    required String title,
+    required String content,
+    required Member member,
+    required BoardType boardType,
+    required DateTime createdAt,
+    @Default(<HashTag>[]) List<HashTag> hashTag,
+    @Default(<Like>[])    List<Like>    like,
+  }) = _Post;
+}
+
+

--- a/lib/community/domain/model/post.dart
+++ b/lib/community/domain/model/post.dart
@@ -1,4 +1,5 @@
 // lib/community/domain/model/post.dart
+import 'package:devlink_mobile_app/auth/domain/model/member.dart';
 import 'package:devlink_mobile_app/community/domain/model/hash_tag.dart';
 import 'package:devlink_mobile_app/community/domain/model/like.dart';
 import 'package:devlink_mobile_app/community/module/util/board_type_enum.dart';

--- a/lib/community/domain/repository/post_repository.dart
+++ b/lib/community/domain/repository/post_repository.dart
@@ -1,0 +1,9 @@
+// lib/community/domain/repository/post_repository.dart
+import 'package:devlink_mobile_app/community/domain/model/post.dart';
+import 'package:devlink_mobile_app/core/result/result.dart';
+
+
+
+abstract interface class PostRepository {
+  Future<Result<List<Post>>> loadPostList();
+}

--- a/lib/community/domain/usecase/load_post_list_use_case.dart
+++ b/lib/community/domain/usecase/load_post_list_use_case.dart
@@ -1,0 +1,11 @@
+// lib/community/domain/usecase/load_post_list_use_case.dart
+import 'package:devlink_mobile_app/community/domain/model/post.dart';
+import 'package:devlink_mobile_app/community/domain/repository/post_repository.dart';
+import 'package:devlink_mobile_app/core/result/result.dart';
+
+class LoadPostListUseCase {
+  const LoadPostListUseCase({required PostRepository repo}) : _repo = repo;
+  final PostRepository _repo;
+
+  Future<Result<List<Post>>> call() => _repo.loadPostList();
+}

--- a/lib/community/domain/usecase/load_post_list_use_case.dart
+++ b/lib/community/domain/usecase/load_post_list_use_case.dart
@@ -7,5 +7,5 @@ class LoadPostListUseCase {
   const LoadPostListUseCase({required PostRepository repo}) : _repo = repo;
   final PostRepository _repo;
 
-  Future<Result<List<Post>>> call() => _repo.loadPostList();
+  Future<Result<List<Post>>> execute() => _repo.loadPostList();
 }

--- a/lib/community/domain/usecase/switch_tab_use_case.dart
+++ b/lib/community/domain/usecase/switch_tab_use_case.dart
@@ -1,5 +1,5 @@
 import 'package:devlink_mobile_app/community/module/util/%08community_tab_type_enum.dart';
 
 class SwitchTabUseCase {
-  CommunityTabType toggle(CommunityTabType current, CommunityTabType next) => next;
+  CommunityTabType execute(CommunityTabType current, CommunityTabType next) => next;
 }

--- a/lib/community/domain/usecase/switch_tab_use_case.dart
+++ b/lib/community/domain/usecase/switch_tab_use_case.dart
@@ -1,0 +1,5 @@
+import '../../presentation/community_list/community_list_state.dart';
+
+class SwitchTabUseCase {
+  CommunityTabType toggle(CommunityTabType current, CommunityTabType next) => next;
+}

--- a/lib/community/domain/usecase/switch_tab_use_case.dart
+++ b/lib/community/domain/usecase/switch_tab_use_case.dart
@@ -1,4 +1,4 @@
-import '../../presentation/community_list/community_list_state.dart';
+import 'package:devlink_mobile_app/community/module/util/%08community_tab_type_enum.dart';
 
 class SwitchTabUseCase {
   CommunityTabType toggle(CommunityTabType current, CommunityTabType next) => next;

--- a/lib/community/module/community_di.dart
+++ b/lib/community/module/community_di.dart
@@ -1,0 +1,25 @@
+import 'package:devlink_mobile_app/community/data/data_source/mock_post_data_source_impl.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../data/data_source/post_data_source.dart';
+
+import '../data/repository_impl/post_repository_impl.dart';
+import '../domain/repository/post_repository.dart';
+import '../domain/usecase/load_post_list_use_case.dart';
+import '../domain/usecase/switch_tab_use_case.dart';
+
+part 'community_di.g.dart';
+
+@riverpod
+PostDataSource postDataSource(Ref ref) => PostDataSourceImpl();
+
+@riverpod
+PostRepository postRepository(Ref ref) =>
+    PostRepositoryImpl(dataSource: ref.watch(postDataSourceProvider));
+
+@riverpod
+LoadPostListUseCase loadPostListUseCase(Ref ref) =>
+    LoadPostListUseCase(repo: ref.watch(postRepositoryProvider));
+
+@riverpod
+SwitchTabUseCase switchTabUseCase(Ref ref) => SwitchTabUseCase();

--- a/lib/community/module/community_route.dart
+++ b/lib/community/module/community_route.dart
@@ -1,0 +1,10 @@
+import 'package:go_router/go_router.dart';
+import '../presentation/community_list/community_list_screen_root.dart';
+
+final communityRoutes = [
+  GoRoute(
+    path: '/community',
+    builder: (context, state) => const CommunityListScreenRoot(),
+  ),
+  // 추가 상세/검색/글쓰기 경로는 이후 구현
+];

--- a/lib/community/module/community_router.dart
+++ b/lib/community/module/community_router.dart
@@ -1,4 +1,5 @@
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../presentation/community_list/community_list_screen_root.dart';
 
 final communityRoutes = [
@@ -8,3 +9,7 @@ final communityRoutes = [
   ),
   // 추가 상세/검색/글쓰기 경로는 이후 구현
 ];
+
+final communityRouterProvider = Provider((ref) {
+  return GoRouter(initialLocation: '/community', routes: communityRoutes);
+});

--- a/lib/community/module/util/community_tab_type_enum.dart
+++ b/lib/community/module/util/community_tab_type_enum.dart
@@ -1,0 +1,1 @@
+enum CommunityTabType { popular, newest }

--- a/lib/community/module/util/board_type_enum.dart
+++ b/lib/community/module/util/board_type_enum.dart
@@ -1,0 +1,1 @@
+enum BoardType { notice, free, qna }

--- a/lib/community/presentation/community_list/community_list_action.dart
+++ b/lib/community/presentation/community_list/community_list_action.dart
@@ -1,3 +1,4 @@
+import 'package:devlink_mobile_app/community/module/util/%08community_tab_type_enum.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 part 'community_list_action.freezed.dart';
 
@@ -5,7 +6,7 @@ part 'community_list_action.freezed.dart';
 sealed class CommunityListAction with _$CommunityListAction {
   const factory CommunityListAction.refresh() = Refresh;
   const factory CommunityListAction.changeTab(CommunityTabType tab) = ChangeTab;
-  const factory CommunityListAction.tapPost(int postId) = TapPost;
+  const factory CommunityListAction.tapPost(String postId) = TapPost;
   const factory CommunityListAction.tapSearch() = TapSearch;
   const factory CommunityListAction.tapWrite() = TapWrite;
 }

--- a/lib/community/presentation/community_list/community_list_action.dart
+++ b/lib/community/presentation/community_list/community_list_action.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'community_list_action.freezed.dart';
+
+@freezed
+sealed class CommunityListAction with _$CommunityListAction {
+  const factory CommunityListAction.refresh() = Refresh;
+  const factory CommunityListAction.changeTab(CommunityTabType tab) = ChangeTab;
+  const factory CommunityListAction.tapPost(int postId) = TapPost;
+  const factory CommunityListAction.tapSearch() = TapSearch;
+  const factory CommunityListAction.tapWrite() = TapWrite;
+}

--- a/lib/community/presentation/community_list/community_list_notifier.dart
+++ b/lib/community/presentation/community_list/community_list_notifier.dart
@@ -2,8 +2,11 @@
 import 'dart:async';
 import 'package:devlink_mobile_app/community/domain/model/post.dart';
 import 'package:devlink_mobile_app/community/domain/usecase/load_post_list_use_case.dart';
+import 'package:devlink_mobile_app/community/module/community_di.dart';
+import 'package:devlink_mobile_app/community/module/util/%08community_tab_type_enum.dart';
 import 'package:devlink_mobile_app/community/presentation/community_list/community_list_action.dart';
 import 'package:devlink_mobile_app/community/presentation/community_list/community_list_state.dart';
+import 'package:devlink_mobile_app/core/result/result.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 
@@ -25,14 +28,12 @@ class CommunityListNotifier extends _$CommunityListNotifier {
   Future<void> _fetch() async {
     state = state.copyWith(postList: const AsyncLoading());
     final result = await _load();
-    result.when(
-      success: (list) {
-        state = state.copyWith(
-          postList: AsyncData(_applySort(list, state.currentTab)),
-        );
-      },
-      error: (f) => state = state.copyWith(postList: AsyncError(f, StackTrace.current)),
-    );
+    switch (result) {
+      case Success(data: final list):
+        state = state.copyWith(postList: AsyncData(list));
+      case Error(failure: final f):
+        state = state.copyWith(postList: AsyncError(f, StackTrace.current));
+    }
   }
 
   /// 탭 변경·수동 새로고침 등 외부 Action 진입점

--- a/lib/community/presentation/community_list/community_list_notifier.dart
+++ b/lib/community/presentation/community_list/community_list_notifier.dart
@@ -16,18 +16,18 @@ part 'community_list_notifier.g.dart';
 class CommunityListNotifier extends _$CommunityListNotifier {
   @override
   CommunityListState build() {
-    _load = ref.watch(loadPostListUseCaseProvider);
+    _loadPostListUseCase = ref.watch(loadPostListUseCaseProvider);
     // 비동기 로딩 → 결과 반영
     Future.microtask(_fetch);
     return const CommunityListState(); // 초기값
   }
 
-  late final LoadPostListUseCase _load;
+  late final LoadPostListUseCase _loadPostListUseCase;
 
   /// 원격 새로고침
   Future<void> _fetch() async {
     state = state.copyWith(postList: const AsyncLoading());
-    final result = await _load();
+    final result = await _loadPostListUseCase.execute();
     switch (result) {
       case Success(data: final list):
         state = state.copyWith(postList: AsyncData(list));

--- a/lib/community/presentation/community_list/community_list_notifier.dart
+++ b/lib/community/presentation/community_list/community_list_notifier.dart
@@ -1,0 +1,67 @@
+// lib/community/presentation/community_list_notifier.dart
+import 'dart:async';
+import 'package:devlink_mobile_app/community/domain/model/post.dart';
+import 'package:devlink_mobile_app/community/domain/usecase/load_post_list_use_case.dart';
+import 'package:devlink_mobile_app/community/presentation/community_list/community_list_action.dart';
+import 'package:devlink_mobile_app/community/presentation/community_list/community_list_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+
+part 'community_list_notifier.g.dart';
+
+@riverpod
+class CommunityListNotifier extends _$CommunityListNotifier {
+  @override
+  CommunityListState build() {
+    _load = ref.watch(loadPostListUseCaseProvider);
+    // 비동기 로딩 → 결과 반영
+    Future.microtask(_fetch);
+    return const CommunityListState(); // 초기값
+  }
+
+  late final LoadPostListUseCase _load;
+
+  /// 원격 새로고침
+  Future<void> _fetch() async {
+    state = state.copyWith(postList: const AsyncLoading());
+    final result = await _load();
+    result.when(
+      success: (list) {
+        state = state.copyWith(
+          postList: AsyncData(_applySort(list, state.currentTab)),
+        );
+      },
+      error: (f) => state = state.copyWith(postList: AsyncError(f, StackTrace.current)),
+    );
+  }
+
+  /// 탭 변경·수동 새로고침 등 외부 Action 진입점
+  Future<void> onAction(CommunityListAction action) async {
+    switch (action) {
+      case Refresh():
+        await _fetch();
+      case ChangeTab(:final tab):
+        state = state.copyWith(
+          currentTab: tab,
+          postList: state.postList.maybeWhen(
+            data: (list) => AsyncData(_applySort(list, tab)),
+            orElse: () => state.postList,
+          ),
+        );
+      default:
+        // UI 이동 Action 은 Root 에서 처리
+        break;
+    }
+  }
+
+  List<Post> _applySort(List<Post> list, CommunityTabType tab) {
+    switch (tab) {
+      case CommunityTabType.popular:
+        final sorted = [...list]..sort((a, b) => b.like.length.compareTo(a.like.length));
+        return sorted;
+      case CommunityTabType.newest:
+        final sorted = [...list]..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+        return sorted;
+    }
+  }
+}

--- a/lib/community/presentation/community_list/community_list_screen.dart
+++ b/lib/community/presentation/community_list/community_list_screen.dart
@@ -79,7 +79,7 @@ class CommunityListScreen extends StatelessWidget {
           physics: const AlwaysScrollableScrollPhysics(),
           itemCount: list.length,
           itemBuilder:
-              (_, i) => PostListItem(
+              (context, i) => PostListItem(
                 post: list[i],
                 onTap: () => onAction(CommunityListAction.tapPost(list[i].id)),
               ),

--- a/lib/community/presentation/community_list/community_list_screen.dart
+++ b/lib/community/presentation/community_list/community_list_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'community_list_state.dart';
+import 'community_list_action.dart';
+import '../component/post_list_item.dart';
+
+class CommunityListScreen extends StatelessWidget {
+  const CommunityListScreen({
+    super.key,
+    required this.state,
+    required this.onAction,
+  });
+
+  final CommunityListState state;
+  final void Function(CommunityListAction action) onAction;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(
+          title: const Text('커뮤니티'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.search),
+              onPressed: () => onAction(const CommunityListAction.tapSearch()),
+            ),
+          ],
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => onAction(const CommunityListAction.tapWrite()),
+          child: const Icon(Icons.edit),
+        ),
+        body: RefreshIndicator(
+          onRefresh: () async => onAction(const CommunityListAction.refresh()),
+          child: Column(
+            children: [
+              _buildTabBar(),
+              Expanded(child: _buildPostList()),
+            ],
+          ),
+        ),
+      );
+
+  Widget _buildTabBar() => TabBar(
+        labelColor: Colors.blue,
+        indicatorColor: Colors.blue,
+        unselectedLabelColor: Colors.grey,
+        onTap: (i) => onAction(
+          CommunityListAction.changeTab(
+            i == 0 ? CommunityTabType.popular : CommunityTabType.newest,
+          ),
+        ),
+        tabs: const [
+          Tab(text: '인기순'),
+          Tab(text: '최신순'),
+        ],
+      );
+
+  Widget _buildPostList() {
+    switch (state.postList) {
+      case AsyncLoading():
+        return const Center(child: CircularProgressIndicator());
+      case AsyncError(:final error, :_):
+        return Center(child: Text((error as Failure).message));
+      case AsyncData(:final value):
+        final list = value ?? [];
+        if (list.isEmpty) {
+          return const Center(child: Text('등록된 게시글이 없습니다'));
+        }
+        return ListView.builder(
+          physics: const AlwaysScrollableScrollPhysics(),
+          itemCount: list.length,
+          itemBuilder: (_, i) => PostListItem(
+            post: list[i],
+            onTap: () => onAction(CommunityListAction.tapPost(list[i].id)),
+          ),
+        );
+    }
+  }
+}

--- a/lib/community/presentation/community_list/community_list_screen.dart
+++ b/lib/community/presentation/community_list/community_list_screen.dart
@@ -1,4 +1,7 @@
+import 'package:devlink_mobile_app/community/module/util/%08community_tab_type_enum.dart';
+import 'package:devlink_mobile_app/core/result/result.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'community_list_state.dart';
 import 'community_list_action.dart';
 import '../component/post_list_item.dart';
@@ -15,64 +18,67 @@ class CommunityListScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Scaffold(
-        appBar: AppBar(
-          title: const Text('커뮤니티'),
-          actions: [
-            IconButton(
-              icon: const Icon(Icons.search),
-              onPressed: () => onAction(const CommunityListAction.tapSearch()),
-            ),
-          ],
+    appBar: AppBar(
+      title: const Text('커뮤니티'),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.search),
+          onPressed: () => onAction(const CommunityListAction.tapSearch()),
         ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () => onAction(const CommunityListAction.tapWrite()),
-          child: const Icon(Icons.edit),
-        ),
-        body: RefreshIndicator(
-          onRefresh: () async => onAction(const CommunityListAction.refresh()),
-          child: Column(
-            children: [
-              _buildTabBar(),
-              Expanded(child: _buildPostList()),
-            ],
+      ],
+    ),
+    floatingActionButton: FloatingActionButton(
+      onPressed: () => onAction(const CommunityListAction.tapWrite()),
+      child: const Icon(Icons.edit),
+    ),
+    body: RefreshIndicator(
+      onRefresh: () async => onAction(const CommunityListAction.refresh()),
+      child: Column(
+        children: [
+          _buildTabBar(),
+          Expanded(
+            child:
+                _buildPostList() ?? const Center(child: Text('등록된 게시글이 없습니다')),
           ),
-        ),
-      );
+        ],
+      ),
+    ),
+  );
 
   Widget _buildTabBar() => TabBar(
-        labelColor: Colors.blue,
-        indicatorColor: Colors.blue,
-        unselectedLabelColor: Colors.grey,
-        onTap: (i) => onAction(
+    labelColor: Colors.blue,
+    indicatorColor: Colors.blue,
+    unselectedLabelColor: Colors.grey,
+    onTap:
+        (i) => onAction(
           CommunityListAction.changeTab(
             i == 0 ? CommunityTabType.popular : CommunityTabType.newest,
           ),
         ),
-        tabs: const [
-          Tab(text: '인기순'),
-          Tab(text: '최신순'),
-        ],
-      );
+    tabs: const [Tab(text: '인기순'), Tab(text: '최신순')],
+  );
 
-  Widget _buildPostList() {
+  Widget? _buildPostList() {
     switch (state.postList) {
       case AsyncLoading():
         return const Center(child: CircularProgressIndicator());
-      case AsyncError(:final error, :_):
+      case AsyncError(:final error):
         return Center(child: Text((error as Failure).message));
       case AsyncData(:final value):
-        final list = value ?? [];
+        final list = value.isNotEmpty ? value : [];
         if (list.isEmpty) {
           return const Center(child: Text('등록된 게시글이 없습니다'));
         }
         return ListView.builder(
           physics: const AlwaysScrollableScrollPhysics(),
           itemCount: list.length,
-          itemBuilder: (_, i) => PostListItem(
-            post: list[i],
-            onTap: () => onAction(CommunityListAction.tapPost(list[i].id)),
-          ),
+          itemBuilder:
+              (_, i) => PostListItem(
+                post: list[i],
+                onTap: () => onAction(CommunityListAction.tapPost(list[i].id)),
+              ),
         );
     }
+    return null;
   }
 }

--- a/lib/community/presentation/community_list/community_list_screen.dart
+++ b/lib/community/presentation/community_list/community_list_screen.dart
@@ -17,33 +17,39 @@ class CommunityListScreen extends StatelessWidget {
   final void Function(CommunityListAction action) onAction;
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-    appBar: AppBar(
-      title: const Text('커뮤니티'),
-      actions: [
-        IconButton(
-          icon: const Icon(Icons.search),
-          onPressed: () => onAction(const CommunityListAction.tapSearch()),
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('커뮤니티'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.search),
+              onPressed: () => onAction(const CommunityListAction.tapSearch()),
+            ),
+          ],
         ),
-      ],
-    ),
-    floatingActionButton: FloatingActionButton(
-      onPressed: () => onAction(const CommunityListAction.tapWrite()),
-      child: const Icon(Icons.edit),
-    ),
-    body: RefreshIndicator(
-      onRefresh: () async => onAction(const CommunityListAction.refresh()),
-      child: Column(
-        children: [
-          _buildTabBar(),
-          Expanded(
-            child:
-                _buildPostList() ?? const Center(child: Text('등록된 게시글이 없습니다')),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => onAction(const CommunityListAction.tapWrite()),
+          child: const Icon(Icons.edit),
+        ),
+        body: RefreshIndicator(
+          onRefresh: () async => onAction(const CommunityListAction.refresh()),
+          child: Column(
+            children: [
+              _buildTabBar(),
+              Expanded(
+                child:
+                    _buildPostList() ??
+                    const Center(child: Text('등록된 게시글이 없습니다')),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
-    ),
-  );
+    );
+  }
 
   Widget _buildTabBar() => TabBar(
     labelColor: Colors.blue,

--- a/lib/community/presentation/community_list/community_list_screen_root.dart
+++ b/lib/community/presentation/community_list/community_list_screen_root.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'community_list_action.dart';
+import 'community_list_notifier.dart';
+import 'community_list_screen.dart';
+
+class CommunityListScreenRoot extends ConsumerWidget {
+  const CommunityListScreenRoot({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(communityListNotifierProvider);
+    final notifier = ref.watch(communityListNotifierProvider.notifier);
+
+    return CommunityListScreen(
+      state: state,
+      onAction: (action) async {
+        switch (action) {
+          case TapPost(:final postId):
+            context.push('/community/$postId');                             // 상세 화면 경로 예시
+          case TapSearch():
+            context.push('/community/search');
+          case TapWrite():
+            context.push('/community/write');
+          default:
+            await notifier.onAction(action);
+        }
+      },
+    );
+  }
+}

--- a/lib/community/presentation/community_list/community_list_screen_root.dart
+++ b/lib/community/presentation/community_list/community_list_screen_root.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'community_list_action.dart';

--- a/lib/community/presentation/community_list/community_list_state.dart
+++ b/lib/community/presentation/community_list/community_list_state.dart
@@ -1,14 +1,15 @@
 import 'package:devlink_mobile_app/community/domain/model/post.dart';
+import 'package:devlink_mobile_app/community/module/util/%08community_tab_type_enum.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 
 part 'community_list_state.freezed.dart';
 
-enum CommunityTabType { popular, newest }
+
 
 @freezed
-class CommunityListState with _$CommunityListState {
+abstract class CommunityListState with _$CommunityListState {
   const factory CommunityListState({
     @Default(AsyncValue<List<Post>>.loading()) AsyncValue<List<Post>> postList,
     @Default(CommunityTabType.popular) CommunityTabType currentTab,

--- a/lib/community/presentation/community_list/community_list_state.dart
+++ b/lib/community/presentation/community_list/community_list_state.dart
@@ -1,0 +1,16 @@
+import 'package:devlink_mobile_app/community/domain/model/post.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+
+part 'community_list_state.freezed.dart';
+
+enum CommunityTabType { popular, newest }
+
+@freezed
+class CommunityListState with _$CommunityListState {
+  const factory CommunityListState({
+    @Default(AsyncValue<List<Post>>.loading()) AsyncValue<List<Post>> postList,
+    @Default(CommunityTabType.popular) CommunityTabType currentTab,
+  }) = _CommunityListState;
+}

--- a/lib/community/presentation/component/post_list_item.dart
+++ b/lib/community/presentation/component/post_list_item.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import '../../domain/model/post.dart';
+
+class PostListItem extends StatelessWidget {
+  const PostListItem({
+    super.key,
+    required this.post,
+    required this.onTap,
+  });
+
+  final Post post;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) => ListTile(
+        title: Text(post.title),
+        subtitle: Text('${post.member.nickname} · ${post.createdAt.toLocal()}'),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.favorite_border, size: 16),
+            const SizedBox(width: 4),
+            Text('${post.like.length}'),
+          ],
+        ),
+        onTap: onTap,
+      );
+}

--- a/lib/community/presentation/component/post_list_item.dart
+++ b/lib/community/presentation/component/post_list_item.dart
@@ -1,5 +1,6 @@
+import 'package:devlink_mobile_app/community/domain/model/post.dart';
 import 'package:flutter/material.dart';
-import '../../domain/model/post.dart';
+
 
 class PostListItem extends StatelessWidget {
   const PostListItem({


### PR DESCRIPTION
## 🚀 주요 변경사항
- 게시판에서 사용할 모델 생성
- 게시판 리스트 화면 생성

## 📷 동작 화면/캡처(옵션)
<img width="599" alt="image" src="https://github.com/user-attachments/assets/0dcd689e-5aa5-4301-a356-3fc38042e020" />


## 💬 참고/이슈 링크(선택)
- 관련 이슈: #50 

