### PR TITLE
[fix] group 모델 수정

### DIFF
--- a/lib/group/data/data_source/mock_group_data_source_impl.dart
+++ b/lib/group/data/data_source/mock_group_data_source_impl.dart
@@ -2,10 +2,12 @@ import 'dart:math';
 import 'package:devlink_mobile_app/community/data/dto/hash_tag_dto.dart';
 import 'package:devlink_mobile_app/community/data/dto/member_dto.dart';
 import 'package:devlink_mobile_app/group/data/dto/group_dto.dart';
+import 'package:intl/intl.dart';
 import 'group_data_source.dart';
 
 class MockGroupDataSourceImpl implements GroupDataSource {
   final Random _random = Random();
+  final DateFormat _dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss');
 
   @override
   Future<List<GroupDto>> fetchGroupList() async {
@@ -14,6 +16,15 @@ class MockGroupDataSourceImpl implements GroupDataSource {
     return List.generate(15, (i) {
       final memberCount = _random.nextInt(10) + 1;
       final limitMemberCount = memberCount + _random.nextInt(10) + 5;
+
+      // 임의의 생성일과 수정일 생성
+      final now = DateTime.now();
+      final createdDate = now.subtract(
+        Duration(days: _random.nextInt(90)),
+      ); // 최대 90일 전
+      final updatedDate = createdDate.add(
+        Duration(days: _random.nextInt(30)),
+      ); // 생성일 이후 최대 30일 후
 
       // 그룹 소유자 생성
       final owner = MemberDto(
@@ -64,6 +75,8 @@ class MockGroupDataSourceImpl implements GroupDataSource {
         limitMemberCount: limitMemberCount,
         owner: owner,
         imageUrl: 'assets/images/group_${i + 1}.png',
+        createdAt: _dateFormat.format(createdDate),
+        updatedAt: _dateFormat.format(updatedDate),
       );
     });
   }

--- a/lib/group/data/dto/group_dto.dart
+++ b/lib/group/data/dto/group_dto.dart
@@ -15,6 +15,8 @@ class GroupDto {
     this.limitMemberCount,
     this.owner,
     this.imageUrl,
+    this.createdAt,
+    this.updatedAt,
   });
 
   final String? id;
@@ -26,6 +28,9 @@ class GroupDto {
   final num? limitMemberCount;
   final MemberDto? owner;
   final String? imageUrl;
+
+  final String? createdAt;
+  final String? updatedAt;
 
   factory GroupDto.fromJson(Map<String, dynamic> json) =>
       _$GroupDtoFromJson(json);

--- a/lib/group/data/mapper/group_mapper.dart
+++ b/lib/group/data/mapper/group_mapper.dart
@@ -46,7 +46,18 @@ extension GroupDtoMapper on GroupDto {
       limitMemberCount: limitMemberCount?.toInt() ?? 0,
       owner: owner?.toModel() ?? defaultOwner,
       imageUrl: imageUrl,
+      createdAt: _parseDateTime(createdAt),
+      updatedAt: _parseDateTime(updatedAt),
     );
+  }
+}
+
+DateTime _parseDateTime(String? dateTimeStr) {
+  if (dateTimeStr == null) return DateTime.now();
+  try {
+    return DateTime.parse(dateTimeStr);
+  } catch (_) {
+    return DateTime.now();
   }
 }
 

--- a/lib/group/domain/model/group.dart
+++ b/lib/group/domain/model/group.dart
@@ -1,6 +1,7 @@
 import 'package:devlink_mobile_app/auth/domain/model/member.dart';
 import 'package:devlink_mobile_app/community/domain/model/hash_tag.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:intl/intl.dart';
 
 part 'group.freezed.dart';
 
@@ -15,6 +16,8 @@ class Group with _$Group {
     required this.limitMemberCount,
     required this.owner,
     this.imageUrl,
+    required this.createdAt,
+    required this.updatedAt,
   });
 
   @override
@@ -33,7 +36,29 @@ class Group with _$Group {
   final Member owner;
   @override
   final String? imageUrl;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime updatedAt;
 
-  // 멤버 수 계산
+  // 현재 그룹 멤버 수
   int get memberCount => members.length;
+
+  // 새 멤버 참여 가능 여부 (memberCount < limitMemberCount)
+  bool get isOpen => memberCount < limitMemberCount;
+
+  // 현재 활동 중인 멤버 수 (타이머 활성 상태)
+  // 참고: Member 클래스에 onAir 속성이 있다고 가정합니다
+  int get activeMemberCount => members.where((member) => member.onAir).length;
+
+  // 포맷된 생성일 문자열
+  String get formattedCreatedDate {
+    final dateFormat = DateFormat('yyyy.MM.dd');
+    return dateFormat.format(createdAt);
+  }
+
+  // 해시태그를 '#태그1 #태그2' 형식으로 결합한 문자열
+  String get hashTagsText {
+    return hashTags.map((tag) => '#${tag.content}').join(' ');
+  }
 }

--- a/lib/group/presentation/group_create/group_create_notifier.dart
+++ b/lib/group/presentation/group_create/group_create_notifier.dart
@@ -117,6 +117,8 @@ class GroupCreateNotifier extends _$GroupCreateNotifier {
         limitMemberCount: state.limitMemberCount,
         owner: owner,
         imageUrl: state.imageUrl,
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
       );
 
       // UseCase 호출하여 그룹 생성

--- a/lib/group/presentation/group_setting/group_settings_notifier.dart
+++ b/lib/group/presentation/group_setting/group_settings_notifier.dart
@@ -152,6 +152,8 @@ class GroupSettingsNotifier extends _$GroupSettingsNotifier {
       limitMemberCount: state.limitMemberCount,
       owner: currentGroup.owner,
       imageUrl: state.imageUrl,
+      createdAt: currentGroup.createdAt,
+      updatedAt: currentGroup.updatedAt,
     );
 
     // 그룹 업데이트

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   hooks_riverpod: ^2.6.1
   go_router: ^15.1.1
   image_picker: ^1.0.4
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 🚀 주요 변경사항
- group 모델에 createdAt과 updateAt를 추가했습니다.
- GroupDto에 대응하는 필드를 추가하고 목 데이터를 생성하도록 수정했습니다.
- 다양한 유용한 계산 속성(computed property)을 추가했습니다:
    `memberCount`: 현재 그룹 멤버 수
    `isOpen`: 새 멤버 참여 가능 여부 (memberCount < limitMemberCount)
    `activeMemberCount`: 현재 활동 중인 멤버 수 (타이머 활성 상태)
    `formattedCreatedDate`: 포맷된 생성일 문자열
    `hashTagsText`: 해시태그를 '#태그1 #태그2' 형식으로 결합한 문자열