### PR TITLE
[fix] 회원가입 및 비밀번호 재설정 화면 오류 수정

### DIFF
--- a/lib/auth/presentation/forgot_password/forgot_password_notifier.dart
+++ b/lib/auth/presentation/forgot_password/forgot_password_notifier.dart
@@ -36,7 +36,7 @@ class ForgotPasswordNotifier extends _$ForgotPasswordNotifier {
           final error = await _validateEmailUseCase.execute(state.email);
           state = state.copyWith(
             emailError: error,
-            formErrorMessage: error != null ? '유효한 이메일을 입력해주세요' : null,
+            // formErrorMessage는 설정하지 않음 (중복 메시지 방지)
           );
         }
 
@@ -50,16 +50,13 @@ class ForgotPasswordNotifier extends _$ForgotPasswordNotifier {
   }
 
   Future<void> _performResetPassword() async {
-    // 통합 오류 메시지 초기화
-    state = state.copyWith(formErrorMessage: null);
-
     // 이메일 유효성 검증
     final emailError = await _validateEmailUseCase.execute(state.email);
     state = state.copyWith(emailError: emailError);
 
-    // 이메일이 유효하지 않으면 중단 및 통합 오류 메시지 설정
+    // 이메일이 유효하지 않으면 중단
     if (emailError != null) {
-      state = state.copyWith(formErrorMessage: '유효한 이메일을 입력해주세요');
+      // formErrorMessage는 설정하지 않음 (중복 메시지 방지)
       return;
     }
 
@@ -101,7 +98,7 @@ class ForgotPasswordNotifier extends _$ForgotPasswordNotifier {
       // 오류 상태 업데이트
       state = state.copyWith(
         resetPasswordResult: result,
-        formErrorMessage: errorMessage,
+        formErrorMessage: errorMessage, // 통합 오류 메시지 설정 (SnackBar 표시용)
       );
     } else {
       // 성공 시 메시지 설정

--- a/lib/auth/presentation/forgot_password/forgot_password_screen_root.dart
+++ b/lib/auth/presentation/forgot_password/forgot_password_screen_root.dart
@@ -21,7 +21,7 @@ class ForgotPasswordScreenRoot extends ConsumerWidget {
       forgotPasswordNotifierProvider.select((value) => value.resetPasswordResult),
           (previous, next) {
         if (previous?.isLoading == true && next?.hasValue == true) {
-          // 성공 메시지 표시
+          // 성공 메시지 표시 (성공은 알려야 함)
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(state.successMessage ?? '이메일이 발송되었습니다.'),
@@ -32,7 +32,7 @@ class ForgotPasswordScreenRoot extends ConsumerWidget {
             ),
           );
         } else if (next?.hasError == true) {
-          // 에러 메시지 처리
+          // 에러 메시지 처리 (네트워크 오류 등 전송 실패는 알려야 함)
           final error = next!.error;
           String errorMessage;
 
@@ -58,12 +58,12 @@ class ForgotPasswordScreenRoot extends ConsumerWidget {
       },
     );
 
-    // 통합 오류 메시지 감지
+    // 통합 오류 메시지 감지는 유지하되 이메일 유효성 관련 메시지는 제외
     ref.listen(
       forgotPasswordNotifierProvider.select((value) => value.formErrorMessage),
           (previous, next) {
-        if (next != null) {
-          // 폼 에러 메시지를 SnackBar로 표시
+        if (next != null && !next.contains('유효한 이메일') && !next.contains('이메일을 입력')) {
+          // 이메일 형식 관련 오류가 아닌 경우에만 SnackBar로 표시
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(next),


### PR DESCRIPTION
1. 이메일 중복 확인 중 에러 발생 시 메시지 표시하지 않도록 수정
2. 회원가입 약관 체크박스 동작 기능 구현
   - 체크박스 클릭 시 자동으로 약관 동의 처리 추가
   - 약관 동의 상태 연동 기능 개선
3. 비밀번호 재설정 화면에서 이메일 유효성 검사 메시지 중복 표시 제거
   - 이메일 필드 아래에만 유효성 오류 메시지 표시
   - SnackBar에는 이메일 유효성 오류가 아닌 실제 전송 오류만 표시

