### PR TITLE
[bug] : 게시글 작성 완료 후 목록 갱신 및 네비게이션 로직 개선

### DIFF
--- a/lib/community/data/data_source/mock_post_data_source_impl.dart
+++ b/lib/community/data/data_source/mock_post_data_source_impl.dart
@@ -1,10 +1,12 @@
 // lib/community/data/data_source/mock_post_data_source_impl.dart
 import 'dart:math';
+
 import 'package:devlink_mobile_app/community/data/dto/comment_dto.dart';
 import 'package:devlink_mobile_app/community/data/dto/like_dto.dart';
 import 'package:devlink_mobile_app/community/data/dto/member_dto.dart';
 import 'package:devlink_mobile_app/community/data/dto/post_dto.dart';
 import 'package:devlink_mobile_app/community/module/util/board_type_enum.dart';
+
 import 'post_data_source.dart';
 
 class PostDataSourceImpl implements PostDataSource {
@@ -130,6 +132,13 @@ class PostDataSourceImpl implements PostDataSource {
   Future<List<PostDto>> fetchPostList() async {
     // 데이터 로딩 시뮬레이션
     await Future.delayed(const Duration(milliseconds: 500));
+
+    // 디버깅 로그 추가
+    print('Mock DataSource: Fetching ${_mockPosts.length} posts');
+    print(
+      'Mock DataSource: First post title: ${_mockPosts.isNotEmpty ? _mockPosts.first.title : "No posts"}',
+    );
+
     return _mockPosts;
   }
 
@@ -144,6 +153,9 @@ class PostDataSourceImpl implements PostDataSource {
       orElse: () => throw Exception('게시글을 찾을 수 없습니다: $postId'),
     );
 
+    print(
+      'Mock DataSource: Fetched post detail - ID: $postId, Title: ${post.title}',
+    );
     return post;
   }
 
@@ -171,6 +183,7 @@ class PostDataSourceImpl implements PostDataSource {
     if (existingLikeIndex >= 0) {
       // 이미 좋아요를 누른 경우, 좋아요 취소
       likes.removeAt(existingLikeIndex);
+      print('Mock DataSource: Like removed from post $postId');
     } else {
       // 좋아요 추가
       likes.add(
@@ -180,6 +193,7 @@ class PostDataSourceImpl implements PostDataSource {
           timestamp: DateTime.now(),
         ),
       );
+      print('Mock DataSource: Like added to post $postId');
     }
 
     // 수정된 게시글 반환
@@ -193,6 +207,7 @@ class PostDataSourceImpl implements PostDataSource {
   Future<PostDto> toggleBookmark(String postId) async {
     await Future.delayed(const Duration(milliseconds: 200));
 
+    print('Mock DataSource: Bookmark toggled for post $postId');
     // 실제 북마크 기능은 여기서 구현하지 않음
     // 해당 ID의 게시글만 반환
     return fetchPostDetail(postId);
@@ -203,7 +218,12 @@ class PostDataSourceImpl implements PostDataSource {
     await Future.delayed(const Duration(milliseconds: 300));
 
     final post = await fetchPostDetail(postId);
-    return post.comment ?? [];
+    final comments = post.comment ?? [];
+
+    print(
+      'Mock DataSource: Fetched ${comments.length} comments for post $postId',
+    );
+    return comments;
   }
 
   @override
@@ -238,6 +258,9 @@ class PostDataSourceImpl implements PostDataSource {
     // 게시글 업데이트
     _mockPosts[postIndex] = post.copyWith(comment: comments);
 
+    print(
+      'Mock DataSource: Comment created for post $postId. Total comments: ${comments.length}',
+    );
     return comments;
   }
 
@@ -250,6 +273,8 @@ class PostDataSourceImpl implements PostDataSource {
     required List<Uri> imageUris,
   }) async {
     await Future.delayed(const Duration(milliseconds: 400));
+
+    print('Mock DataSource: Creating post with ID: $postId, Title: $title');
 
     // 새 게시글 생성
     final newPost = PostDto(
@@ -272,8 +297,13 @@ class PostDataSourceImpl implements PostDataSource {
       comment: [],
     );
 
-    // 목 데이터에 추가
-    _mockPosts.insert(0, newPost); // 최신 게시글이 맨 앞에 오도록
+    // 목 데이터에 추가 (맨 앞에 추가하여 최신 게시글이 위에 오도록)
+    _mockPosts.insert(0, newPost);
+
+    print(
+      'Mock DataSource: Post created successfully. Total posts: ${_mockPosts.length}',
+    );
+    print('Mock DataSource: First post is now: ${_mockPosts.first.title}');
 
     return postId;
   }
@@ -299,129 +329,9 @@ class PostDataSourceImpl implements PostDataSource {
           return titleMatch || contentMatch || tagMatch;
         }).toList();
 
+    print(
+      'Mock DataSource: Search for "$query" returned ${results.length} results',
+    );
     return results;
   }
-
-  // /* ---------- 목록 ---------- */
-  // @override
-  // Future<List<PostDto>> fetchPostList() async {
-  //   await Future<void>.delayed(const Duration(milliseconds: 500));
-  //   return List.generate(30, _mock);
-  // }
-
-  // /* ---------- 상세 ---------- */
-  // @override
-  // Future<PostDto> fetchPostDetail(String postId) async {
-  //   await Future<void>.delayed(const Duration(milliseconds: 400));
-  //   return _mock(int.parse(postId.split('_').last));
-  // }
-
-  // /* ---------- Toggle ---------- */
-  // @override
-  // Future<PostDto> toggleLike(String postId) async {
-  //   await Future<void>.delayed(const Duration(milliseconds: 250));
-  //   final dto = await fetchPostDetail(postId);
-  //   dto.like?.add(
-  //     LikeDto(userId: 'user_me', userName: '현재 사용자', timestamp: DateTime.now()),
-  //   );
-  //   return dto;
-  // }
-  //
-  // @override
-  // Future<PostDto> toggleBookmark(String postId) async {
-  //   await Future<void>.delayed(const Duration(milliseconds: 250));
-  //   return fetchPostDetail(postId); // 북마크 상태는 별도 DTO 필드가 없으므로 그대로 반환
-  // }
-
-  // /* ---------- 댓글 ---------- */
-  // @override
-  // Future<List<CommentDto>> fetchComments(String postId) async {
-  //   await Future<void>.delayed(const Duration(milliseconds: 300));
-  //   return List.generate(7, (i) => _mockComment(postId, i));
-  // }
-  //
-  // @override
-  // Future<List<CommentDto>> createComment({
-  //   required String postId,
-  //   required String memberId,
-  //   required String content,
-  // }) async {
-  //   await Future<void>.delayed(const Duration(milliseconds: 200));
-  //   final list = await fetchComments(postId);
-  //   return [
-  //     CommentDto(
-  //       userId: memberId,
-  //       userName: "현재 사용자",
-  //       userProfileImage:
-  //           "https://i.namu.wiki/i/R0AhIJhNi8fkU2Al72pglkrT8QenAaCJd1as-d_iY6MC8nub1iI5VzIqzJlLa-1uzZm--TkB-KHFiT-P-t7bEg.webp",
-  //       text: content,
-  //       createdAt: DateTime.now(),
-  //       likeCount: 0,
-  //     ),
-  //     ...list,
-  //   ];
-  // }
-  //
-  // /* ---------- NEW ---------- */
-  // @override
-  // Future<String> createPost({
-  //   required String title,
-  //   required String content,
-  //   required List<String> hashTags,
-  //   required List<Uri> imageUris,
-  // }) async {
-  //   await Future<void>.delayed(const Duration(milliseconds: 400));
-  //   // 실제 API 호출 자리. 여기서는 새 random id 반환
-  //   final newId = 'post_${_rand.nextInt(100000)}';
-  //   return newId;
-  // }
-  //
-  // /* ---------- Mock Helpers ---------- */
-  // PostDto _mock(int i) {
-  //   final likeCnt = _rand.nextInt(200);
-  //   return PostDto(
-  //     id: 'post_$i',
-  //     title: '목 게시글 $i',
-  //     content: '[Mock] 내용 $i',
-  //     member: MemberDto(
-  //       id: 'u$i',
-  //       email: 'user$i@mail.com',
-  //       nickname: 'user$i',
-  //       uid: 'uid_$i',
-  //       onAir: i.isEven,
-  //       image:
-  //           'https://i.namu.wiki/i/R0AhIJhNi8fkU2Al72pglkrT8QenAaCJd1as-d_iY6MC8nub1iI5VzIqzJlLa-1uzZm--TkB-KHFiT-P-t7bEg.webp',
-  //     ),
-  //     userProfileImage:
-  //         'https://i.namu.wiki/i/R0AhIJhNi8fkU2Al72pglkrT8QenAaCJd1as-d_iY6MC8nub1iI5VzIqzJlLa-1uzZm--TkB-KHFiT-P-t7bEg.webp',
-  //     boardType: BoardType.free,
-  //     createdAt: DateTime.now().subtract(Duration(minutes: i * 5)),
-  //     hashTags: ['#태그${i % 3}', if (i.isEven) '#인기'],
-  //     mediaUrls:
-  //         i % 3 == 0
-  //             ? [
-  //               'https://i.namu.wiki/i/R0AhIJhNi8fkU2Al72pglkrT8QenAaCJd1as-d_iY6MC8nub1iI5VzIqzJlLa-1uzZm--TkB-KHFiT-P-t7bEg.webp',
-  //             ]
-  //             : [],
-  //     like: List.generate(
-  //       likeCnt,
-  //       (idx) => LikeDto(
-  //         userId: 'u$idx',
-  //         userName: 'user$idx',
-  //         timestamp: DateTime.now().subtract(Duration(hours: idx)),
-  //       ),
-  //     ),
-  //     comment: [_mockComment('post_$i', i)],
-  //   );
-  // }
-  //
-  // CommentDto _mockComment(String postId, int i) => CommentDto(
-  //   userId: 'u$i',
-  //   userName: '사용자$i',
-  //   userProfileImage:
-  //       'https://i.namu.wiki/i/R0AhIJhNi8fkU2Al72pglkrT8QenAaCJd1as-d_iY6MC8nub1iI5VzIqzJlLa-1uzZm--TkB-KHFiT-P-t7bEg.webp',
-  //   text: '저도 참여하고 싶습니다!',
-  //   createdAt: DateTime(2025, 4, 28),
-  //   likeCount: _rand.nextInt(50),
-  // );
 }

--- a/lib/community/module/community_di.dart
+++ b/lib/community/module/community_di.dart
@@ -1,17 +1,16 @@
 // lib/community/module/community_di.dart
 import 'package:devlink_mobile_app/community/data/data_source/mock_post_data_source_impl.dart';
-import 'package:devlink_mobile_app/community/data/data_source/post_firebase_data_source.dart';
 import 'package:devlink_mobile_app/community/domain/usecase/create_comment_use_case.dart';
 import 'package:devlink_mobile_app/community/domain/usecase/create_post_use_case.dart';
 import 'package:devlink_mobile_app/community/domain/usecase/fetch_comments_use_case.dart';
 import 'package:devlink_mobile_app/community/domain/usecase/fetch_post_detail_use_case.dart';
-import 'package:devlink_mobile_app/community/domain/usecase/search_posts_use_case.dart';  // 새로 추가
+import 'package:devlink_mobile_app/community/domain/usecase/search_posts_use_case.dart'; // 새로 추가
 import 'package:devlink_mobile_app/community/domain/usecase/toggle_bookmark_use_case.dart';
 import 'package:devlink_mobile_app/community/domain/usecase/toggle_like_use_case.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import '../data/data_source/post_data_source.dart';
 
+import '../data/data_source/post_data_source.dart';
 import '../data/repository_impl/post_repository_impl.dart';
 import '../domain/repository/post_repository.dart';
 import '../domain/usecase/load_post_list_use_case.dart';
@@ -19,9 +18,16 @@ import '../domain/usecase/switch_tab_use_case.dart';
 
 part 'community_di.g.dart';
 
+// 데이터소스 - 싱글톤처럼 관리
+@Riverpod(keepAlive: true)
+PostDataSource postDataSource(Ref ref) {
+  print('Provider: Creating PostDataSource instance');
+  final instance = PostDataSourceImpl();
+  return instance;
+}
 // 데이터소스
-@riverpod
-PostDataSource postDataSource(Ref ref) => PostDataSourceImpl();
+// @riverpod
+// PostDataSource postDataSource(Ref ref) => PostDataSourceImpl();
 
 // @riverpod
 // PostDataSource postDataSource(Ref ref) => PostFirebaseDataSource();

--- a/lib/community/presentation/community_list/community_list_notifier.dart
+++ b/lib/community/presentation/community_list/community_list_notifier.dart
@@ -1,79 +1,148 @@
 // lib/community/presentation/community_list/community_list_notifier.dart
 
 import 'dart:async';
+
 import 'package:devlink_mobile_app/community/domain/model/post.dart';
 import 'package:devlink_mobile_app/community/domain/usecase/load_post_list_use_case.dart';
 import 'package:devlink_mobile_app/community/module/community_di.dart';
 import 'package:devlink_mobile_app/community/module/util/community_tab_type_enum.dart';
-
 import 'package:devlink_mobile_app/community/presentation/community_list/community_list_action.dart';
 import 'package:devlink_mobile_app/community/presentation/community_list/community_list_state.dart';
+import 'package:devlink_mobile_app/community/presentation/community_write/community_write_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'community_list_notifier.g.dart';
-
 
 @riverpod
 class CommunityListNotifier extends _$CommunityListNotifier {
   @override
   CommunityListState build() {
     _loadPostListUseCase = ref.watch(loadPostListUseCaseProvider);
-    // 비동기 로딩 → 결과 반영
+
+    // 글쓰기 완료 감지하여 자동 갱신
+    // TODO: 차후 공통 이벤트 상태 관리 시스템으로 리팩토링 필요
+    // 현재는 Mock 상태이므로 글쓰기 완료를 직접 감지하여 목록 갱신
+    // 추후 AppEventNotifier 같은 중앙 이벤트 관리자로 대체 예정
+    // AppEventNotifier의 상태 변경을 구독하고, 자기 하위의 Root에 전달하기 위해
+    // CommunityListState 내 refresh 등의 상태 갱신하는 로직 필요
+    ref.listen(
+      communityWriteNotifierProvider.select((state) => state.createdPostId),
+      (previous, current) {
+        if (previous == null && current != null) {
+          Future.microtask(() => _fetch());
+        }
+      },
+    );
+
     Future.microtask(_fetch);
-    return const CommunityListState(currentTab: CommunityTabType.newest); // 최신순으로 기본값 설정
+    return const CommunityListState(currentTab: CommunityTabType.newest);
   }
 
   late final LoadPostListUseCase _loadPostListUseCase;
 
   /// 원격 새로고침
   Future<void> _fetch() async {
+    print('CommunityListNotifier: _fetch() started');
     state = state.copyWith(postList: const AsyncLoading());
-    final result = await _loadPostListUseCase.execute();
-    
-    // switch-case 패턴 사용
-    switch (result) {
-      case AsyncData(:final value):
-        state = state.copyWith(
-          postList: AsyncData(_applySort(value, state.currentTab))
-        );
-      case AsyncError(:final error, :final stackTrace):
-        state = state.copyWith(postList: AsyncError(error, stackTrace));
-      case AsyncLoading():
-        // 이미 위에서 AsyncLoading으로 설정했으므로 여기서는 처리 불필요
-        break;
+
+    try {
+      final result = await _loadPostListUseCase.execute();
+      print('CommunityListNotifier: UseCase executed, processing result...');
+
+      // switch-case 패턴 사용
+      switch (result) {
+        case AsyncData(:final value):
+          final sortedPosts = _applySort(value, state.currentTab);
+          state = state.copyWith(postList: AsyncData(sortedPosts));
+          print(
+            'CommunityListNotifier: Successfully loaded ${sortedPosts.length} posts',
+          );
+          print(
+            'CommunityListNotifier: First post title: ${sortedPosts.isNotEmpty ? sortedPosts.first.title : "No posts"}',
+          );
+
+        case AsyncError(:final error, :final stackTrace):
+          state = state.copyWith(postList: AsyncError(error, stackTrace));
+          print('CommunityListNotifier: Error loading posts: $error');
+
+        case AsyncLoading():
+          // 이미 위에서 AsyncLoading으로 설정했으므로 여기서는 처리 불필요
+          print('CommunityListNotifier: Still loading...');
+          break;
+      }
+    } catch (e) {
+      print('CommunityListNotifier: Unexpected error in _fetch(): $e');
+      state = state.copyWith(postList: AsyncError(e, StackTrace.current));
     }
+
+    print('CommunityListNotifier: _fetch() completed');
   }
 
   /// 탭 변경·수동 새로고침 등 외부 Action 진입점
   Future<void> onAction(CommunityListAction action) async {
+    print('CommunityListNotifier: onAction called with $action');
+
     switch (action) {
       case Refresh():
+        print('CommunityListNotifier: Refresh action received');
         await _fetch(); // 전체 목록 다시 불러오기
-        
+
       case ChangeTab(:final tab):
+        print(
+          'CommunityListNotifier: ChangeTab action received. New tab: $tab',
+        );
         // 탭 변경 시 게시글 다시 불러오기 (추가)
         state = state.copyWith(currentTab: tab);
         await _fetch(); // 전체 목록 다시 불러온 후 정렬 적용
-        
+
       case TapSearch():
+        print(
+          'CommunityListNotifier: TapSearch action received (handled by Root)',
+        );
         // 화면 이동은 Root에서 처리하므로 여기서는 아무 작업도 수행하지 않음
         break;
+
       case TapWrite():
+        print(
+          'CommunityListNotifier: TapWrite action received (handled by Root)',
+        );
         // 화면 이동은 Root에서 처리하므로 여기서는 아무 작업도 수행하지 않음
         break;
+
       case TapPost():
+        print(
+          'CommunityListNotifier: TapPost action received (handled by Root)',
+        );
         // 화면 이동은 Root에서 처리하므로 여기서는 아무 작업도 수행하지 않음
         break;
     }
+
+    print('CommunityListNotifier: onAction completed for $action');
   }
 
   List<Post> _applySort(List<Post> list, CommunityTabType tab) {
+    print('CommunityListNotifier: Applying sort for tab: $tab');
+
     switch (tab) {
       case CommunityTabType.popular:
-        final sorted = [...list]..sort((a, b) => b.like.length.compareTo(a.like.length));
+        final sorted = [...list]
+          ..sort((a, b) => b.like.length.compareTo(a.like.length));
+        print(
+          'CommunityListNotifier: Sorted by popularity (${sorted.length} posts)',
+        );
         return sorted;
+
       case CommunityTabType.newest:
-        final sorted = [...list]..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+        final sorted = [...list]
+          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+        print(
+          'CommunityListNotifier: Sorted by newest (${sorted.length} posts)',
+        );
+        if (sorted.isNotEmpty) {
+          print(
+            'CommunityListNotifier: Newest post: ${sorted.first.title} (${sorted.first.createdAt})',
+          );
+        }
         return sorted;
     }
   }

--- a/lib/community/presentation/community_write/community_write_notifier.dart
+++ b/lib/community/presentation/community_write/community_write_notifier.dart
@@ -1,6 +1,7 @@
 // lib/community/presentation/community_write/community_write_notifier.dart
 import 'dart:io';
 import 'dart:math';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:devlink_mobile_app/community/domain/usecase/create_post_use_case.dart';
 import 'package:devlink_mobile_app/community/module/community_di.dart';
@@ -62,8 +63,8 @@ class CommunityWriteNotifier extends _$CommunityWriteNotifier {
         await _submit();
 
       case NavigateBack(:final postId):
-      // Root에서 처리하므로 여기서는 아무 것도 하지 않음
-      break;
+        // Root에서 처리하므로 여기서는 아무 것도 하지 않음
+        break;
     }
   }
 

--- a/lib/community/presentation/community_write/community_write_screen_root.dart
+++ b/lib/community/presentation/community_write/community_write_screen_root.dart
@@ -1,62 +1,50 @@
 // lib/community/presentation/community_write/community_write_screen_root.dart
-import 'package:devlink_mobile_app/community/module/util/community_tab_type_enum.dart';
-import 'package:devlink_mobile_app/community/presentation/community_list/community_list_action.dart';
-import 'package:devlink_mobile_app/community/presentation/community_list/community_list_notifier.dart';
+import 'package:devlink_mobile_app/community/presentation/community_write/community_write_notifier.dart';
+import 'package:devlink_mobile_app/community/presentation/community_write/community_write_screen.dart';
 import 'package:devlink_mobile_app/community/presentation/community_write/community_write_state.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:devlink_mobile_app/community/presentation/community_write/community_write_action.dart';
-import 'package:devlink_mobile_app/community/presentation/community_write/community_write_notifier.dart';
-import 'package:devlink_mobile_app/community/presentation/community_write/community_write_screen.dart';
 
-class CommunityWriteScreenRoot extends ConsumerStatefulWidget {
+class CommunityWriteScreenRoot extends ConsumerWidget {
   const CommunityWriteScreenRoot({super.key});
 
   @override
-  ConsumerState<CommunityWriteScreenRoot> createState() =>
-      _CommunityWriteScreenRootState();
-}
-
-class _CommunityWriteScreenRootState
-    extends ConsumerState<CommunityWriteScreenRoot> {
-  @override
-  void initState() {
-    super.initState();
-
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 게시글 작성 완료 감지
     ref.listen<CommunityWriteState>(communityWriteNotifierProvider, (
       previous,
       current,
     ) {
-      // 이전 상태에는 ID가 없고, 현재 상태에는 ID가 있는 경우
+      // 이전 상태에는 ID가 없고, 현재 상태에는 ID가 있는 경우 (게시글 생성 완료)
       if (previous?.createdPostId == null && current.createdPostId != null) {
-        print('Post created, directly refreshing list');
+        // 다음 프레임에서 실행하여 안전하게 처리
+        WidgetsBinding.instance.addPostFrameCallback((_) async {
+          if (context.mounted) {
+            try {
+              // 현재 경로 확인
+              final currentLocation = GoRouterState.of(context).uri.path;
+              final isOnCommunityTab = currentLocation == '/community';
 
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          // Community List Notifier 직접 접근
-          final communityListNotifier = ref.read(
-            communityListNotifierProvider.notifier,
-          );
+              // 1. 글쓰기 화면 닫기
+              if (context.canPop()) {
+                context.pop();
+              }
 
-          // 직접 새로고침 및 탭 변경 호출
-          communityListNotifier.onAction(const CommunityListAction.refresh());
-          communityListNotifier.onAction(
-            const CommunityListAction.changeTab(CommunityTabType.newest),
-          );
-
-          // 목록 화면으로 이동
-          if (context.canPop()) {
-            context.pop();
-          } else {
-            context.go('/community');
+              if (!isOnCommunityTab) {
+                // 이동 후 CommunityListRoot에서 자동으로 갱신 감지 처리
+                context.go('/community');
+              }
+            } catch (e) {
+              print(
+                'CommunityWriteRoot: Error during post-creation process: $e',
+              );
+            }
           }
         });
       }
     });
-  }
 
-  @override
-  Widget build(BuildContext context) {
     final state = ref.watch(communityWriteNotifierProvider);
     final notifier = ref.watch(communityWriteNotifierProvider.notifier);
 


### PR DESCRIPTION
- 탭 판단 로직 수정: startsWith('/community') → == '/community'로 정확한 경로 매칭
- 중복 갱신 로직 제거: build() 자동 초기화와 강제 갱신 중복 해결
- CommunityListRoot에서 글쓰기 상태 감지하여 자동 목록 갱신 구현
- CommunityWriteRoot는 단순 이동만 담당하도록 책임 분리
- 불필요한 300ms 지연 제거 및 아키텍처 개선
- 향후 중앙 이벤트 관리 시스템 도입을 위한 TODO 주석 추가