### PR TITLE
[fix] 그룹 생성 후 네비게이션을 pushReplacement로 변경하여 백버튼 동작 개선

### DIFF
--- a/lib/group/module/group_di.dart
+++ b/lib/group/module/group_di.dart
@@ -1,4 +1,3 @@
-import 'package:devlink_mobile_app/auth/module/auth_di.dart';
 import 'package:devlink_mobile_app/group/data/data_source/group_data_source.dart';
 import 'package:devlink_mobile_app/group/data/data_source/mock_group_data_source_impl.dart';
 import 'package:devlink_mobile_app/group/data/data_source/mock_timer_data_source_impl.dart';
@@ -8,9 +7,9 @@ import 'package:devlink_mobile_app/group/data/repository_impl/timer_repository_i
 import 'package:devlink_mobile_app/group/domain/repository/group_repository.dart';
 import 'package:devlink_mobile_app/group/domain/repository/timer_repository.dart';
 import 'package:devlink_mobile_app/group/domain/usecase/create_group_use_case.dart';
+import 'package:devlink_mobile_app/group/domain/usecase/get_current_member_use_case.dart';
 import 'package:devlink_mobile_app/group/domain/usecase/get_group_detail_use_case.dart';
 import 'package:devlink_mobile_app/group/domain/usecase/get_group_list_use_case.dart';
-import 'package:devlink_mobile_app/group/domain/usecase/get_current_member_use_case.dart';
 import 'package:devlink_mobile_app/group/domain/usecase/get_member_timers_use_case.dart';
 import 'package:devlink_mobile_app/group/domain/usecase/get_timer_sessions_use_case.dart';
 import 'package:devlink_mobile_app/group/domain/usecase/join_group_use_case.dart';
@@ -32,7 +31,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'group_di.g.dart';
 
 // DataSource 프로바이더
-@riverpod
+@Riverpod(keepAlive: true)
 GroupDataSource groupDataSource(Ref ref) => MockGroupDataSourceImpl();
 
 // Repository 프로바이더

--- a/lib/group/presentation/group_create/group_create_screen_root.dart
+++ b/lib/group/presentation/group_create/group_create_screen_root.dart
@@ -30,7 +30,7 @@ class GroupCreateScreenRoot extends ConsumerWidget {
           print('🔄 Navigating to group with ID: $next');
 
           // 그룹 상세 페이지로 이동 (확실하게 경로 지정)
-          context.go('/group/$next'); // push 대신 go 사용
+          context.pushReplacement('/group/$next');
         }
       },
     );


### PR DESCRIPTION
## 🚀 주요 변경사항
 - 그룹 생성 후 네비게이션을 pushReplacement로 변경하여 백버튼 동작 개선
 - Mock DataSource를 keepAlive로 설정하여 생성된 그룹 데이터 유지


## 💬 참고/이슈 링크(선택)
- 관련 이슈: #239 
- 참고사항/의논사항: 문서 업데이트 필요
