### PR TITLE
[fix] 그룹 목록 조회 시 사용자의 가입 여부 반영 오류 수정

### DIFF
--- a/lib/group/data/mapper/group_mapper.dart
+++ b/lib/group/data/mapper/group_mapper.dart
@@ -53,9 +53,48 @@ extension GroupModelListMapper on List<Group> {
   List<GroupDto> toDtoList() => map((e) => e.toDto()).toList();
 }
 
-/// Map<String, dynamic> → GroupDto 변환
+/// 🔧 Map<String, dynamic> → GroupDto 변환 (isJoinedByCurrentUser 보존)
 extension MapToGroupDtoMapper on Map<String, dynamic> {
-  GroupDto toGroupDto() => GroupDto.fromJson(this);
+  GroupDto toGroupDto() {
+    // 기본 DTO 생성
+    final dto = GroupDto.fromJson(this);
+
+    // isJoinedByCurrentUser 직접 추출하여 설정
+    final isJoined = this['isJoinedByCurrentUser'] as bool? ?? false;
+
+    return dto.copyWith(isJoinedByCurrentUser: isJoined);
+  }
+}
+
+/// 🔧 Map 리스트를 Group 리스트로 직접 변환 (Repository에서 사용)
+extension MapListToGroupListMapper on List<Map<String, dynamic>>? {
+  List<Group> toGroupModelList() {
+    if (this == null || this!.isEmpty) return [];
+
+    return this!.map((data) {
+      // isJoinedByCurrentUser 직접 추출
+      final isJoined = data['isJoinedByCurrentUser'] as bool? ?? false;
+
+      // GroupDto 생성
+      final dto = GroupDto.fromJson(data);
+
+      // Group 모델 생성 시 isJoinedByCurrentUser 직접 설정
+      return Group(
+        id: dto.id ?? '',
+        name: dto.name ?? '',
+        description: dto.description ?? '',
+        imageUrl: dto.imageUrl,
+        createdAt: dto.createdAt ?? DateTime.now(),
+        ownerId: dto.ownerId ?? '',
+        ownerNickname: dto.ownerNickname,
+        ownerProfileImage: dto.ownerProfileImage,
+        maxMemberCount: dto.maxMemberCount ?? 10,
+        hashTags: dto.hashTags ?? [],
+        memberCount: dto.memberCount ?? 0,
+        isJoinedByCurrentUser: isJoined, // 🔧 원본 데이터에서 직접 가져온 값 사용
+      );
+    }).toList();
+  }
 }
 
 /// JoinedGroupDto → Group 변환 (간소화된 버전)

--- a/lib/group/data/repository_impl/group_repository_impl.dart
+++ b/lib/group/data/repository_impl/group_repository_impl.dart
@@ -24,10 +24,8 @@ class GroupRepositoryImpl implements GroupRepository {
       // DataSource에서 직접 그룹 목록 조회 (내부에서 현재 사용자의 가입 정보 처리)
       final groupsData = await _dataSource.fetchGroupList();
 
-      // Map<String, dynamic> → GroupDto → Group 변환
-      final groupDtos =
-          groupsData.map((data) => GroupDto.fromJson(data)).toList();
-      final groups = groupDtos.toModelList();
+      // 🔧 새로운 Mapper 사용: Map 리스트를 Group 리스트로 직접 변환
+      final groups = groupsData.toGroupModelList();
 
       return Result.success(groups);
     } catch (e, st) {


### PR DESCRIPTION
## 🚀 주요 변경사항
- `GroupFirebaseDataSource`:
    - `_getCurrentUserJoinedGroupIds`: Firestore에서 사용자 가입 그룹 ID 조회 로직 개선 및 디버깅 로그 추가
    - `fetchGroupList`: 조회된 그룹 데이터에 `isJoinedByCurrentUser` 필드를 직접 추가하도록 수정
- `GroupMapper`:
    - `MapToGroupDtoMapper`: `toGroupDto` 메서드가 `isJoinedByCurrentUser` 값을 DTO에 올바르게 전달하도록 수정
    - `MapListToGroupListMapper`: `Map<String, dynamic>` 리스트를 `Group` 모델 리스트로 변환 시, `isJoinedByCurrentUser` 값을 직접 사용하도록 새로운 매퍼 추가
- `GroupRepositoryImpl`:
    - `getGroupList`: `MapListToGroupListMapper`를 사용하여 Firestore 데이터를 `Group` 모델로 변환하도록 수정하여 `isJoinedByCurrentUser` 값 누락 문제 해결


## 💬 참고/이슈 링크(선택)
- 관련 이슈: #301 
- 참고사항/의논사항: mapper 문제였음
