### PR TITLE
feat(group): 실시간 그룹 멤버 타이머 상태 스트림 추가

### DIFF
--- a/lib/group/data/data_source/group_data_source.dart
+++ b/lib/group/data/data_source/group_data_source.dart
@@ -27,8 +27,13 @@ abstract interface class GroupDataSource {
   /// 그룹의 모든 멤버 조회
   Future<List<Map<String, dynamic>>> fetchGroupMembers(String groupId);
 
-  /// 그룹의 모든 타이머 활동 조회 (최신순, 멤버별 필터링)
+  // 그룹의 모든 타이머 활동 조회 (최신순, 멤버별 필터링)
   Future<List<Map<String, dynamic>>> fetchGroupTimerActivities(String groupId);
+
+  /// 실시간 타이머 상태 스트림 조회 - 타이머 화면 표시용
+  Stream<List<Map<String, dynamic>>> streamGroupMemberTimerStatus(
+    String groupId,
+  );
 
   /// 그룹 이미지 업데이트
   Future<String> updateGroupImage(String groupId, String localImagePath);

--- a/lib/group/domain/repository/group_repository.dart
+++ b/lib/group/domain/repository/group_repository.dart
@@ -21,8 +21,13 @@ abstract interface class GroupRepository {
   /// 멤버 타이머 일시정지/재개
   Future<Result<void>> pauseMemberTimer(String groupId);
 
-  /// 그룹 멤버 목록과 해당 타이머 상태 조회
+  /// 그룹 멤버 목록과 해당 타이머 상태 조회 (한 번만 조회)
   Future<Result<List<GroupMember>>> getGroupMembers(String groupId);
+
+  /// 🔧 새로운 실시간 그룹 멤버 타이머 상태 스트림
+  Stream<Result<List<GroupMember>>> streamGroupMemberTimerStatus(
+    String groupId,
+  );
 
   /// 특정 그룹의 특정 월 출석 기록 조회
   Future<Result<List<Attendance>>> getAttendancesByMonth(

--- a/lib/group/domain/usecase/stream_group_member_timer_status_use_case.dart
+++ b/lib/group/domain/usecase/stream_group_member_timer_status_use_case.dart
@@ -1,0 +1,30 @@
+// lib/group/domain/usecase/stream_group_member_timer_status_use_case.dart
+import 'package:devlink_mobile_app/core/result/result.dart';
+import 'package:devlink_mobile_app/group/domain/model/group_member.dart';
+import 'package:devlink_mobile_app/group/domain/repository/group_repository.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class StreamGroupMemberTimerStatusUseCase {
+  final GroupRepository _repository;
+
+  StreamGroupMemberTimerStatusUseCase({required GroupRepository repository})
+    : _repository = repository;
+
+  /// 실시간 그룹 멤버 타이머 상태 스트림
+  ///
+  /// Repository에서 받은 Result<List<GroupMember>> 스트림을
+  /// AsyncValue<List<GroupMember>> 스트림으로 변환하여 반환
+  Stream<AsyncValue<List<GroupMember>>> execute(String groupId) {
+    return _repository
+        .streamGroupMemberTimerStatus(groupId)
+        .map(
+          (result) => switch (result) {
+            Success(:final data) => AsyncData(data),
+            Error(:final failure) => AsyncError(
+              failure,
+              failure.stackTrace ?? StackTrace.current,
+            ),
+          },
+        );
+  }
+}

--- a/lib/group/module/group_di.dart
+++ b/lib/group/module/group_di.dart
@@ -24,6 +24,7 @@ import 'package:devlink_mobile_app/group/domain/usecase/search_groups_use_case.d
 import 'package:devlink_mobile_app/group/domain/usecase/send_message_use_case.dart';
 import 'package:devlink_mobile_app/group/domain/usecase/start_timer_use_case.dart';
 import 'package:devlink_mobile_app/group/domain/usecase/stop_timer_use_case.dart';
+import 'package:devlink_mobile_app/group/domain/usecase/stream_group_member_timer_status_use_case.dart';
 import 'package:devlink_mobile_app/group/domain/usecase/update_group_use_case.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/foundation.dart';
@@ -106,7 +107,7 @@ LeaveGroupUseCase leaveGroupUseCase(Ref ref) =>
 SearchGroupsUseCase searchGroupsUseCase(Ref ref) =>
     SearchGroupsUseCase(repository: ref.watch(groupRepositoryProvider));
 
-// 새로 추가된 UseCase 프로바이더들
+// 기존 UseCase 프로바이더들
 @riverpod
 GetGroupMembersUseCase getGroupMembersUseCase(Ref ref) =>
     GetGroupMembersUseCase(repository: ref.watch(groupRepositoryProvider));
@@ -128,6 +129,14 @@ StopTimerUseCase stopTimerUseCase(Ref ref) =>
 @riverpod
 PauseTimerUseCase pauseTimerUseCase(Ref ref) =>
     PauseTimerUseCase(repository: ref.watch(groupRepositoryProvider));
+
+// 🔧 새로운 실시간 스트림 UseCase Provider 추가
+@riverpod
+StreamGroupMemberTimerStatusUseCase streamGroupMemberTimerStatusUseCase(
+  Ref ref,
+) => StreamGroupMemberTimerStatusUseCase(
+  repository: ref.watch(groupRepositoryProvider),
+);
 
 // Group chat UseCase
 

--- a/lib/group/presentation/group_detail/group_detail_notifier.dart
+++ b/lib/group/presentation/group_detail/group_detail_notifier.dart
@@ -22,13 +22,13 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
   Timer? _timer;
   StreamSubscription? _timerStatusSubscription;
 
-  late final StartTimerUseCase _startTimerUseCase;
-  late final StopTimerUseCase _stopTimerUseCase;
-  late final PauseTimerUseCase _pauseTimerUseCase;
-  late final GetGroupDetailUseCase _getGroupDetailUseCase;
-  late final GetGroupMembersUseCase _getGroupMembersUseCase;
-  late final StreamGroupMemberTimerStatusUseCase
-  _streamGroupMemberTimerStatusUseCase;
+  // 🔧 late 필드를 nullable로 변경하여 중복 초기화 문제 해결
+  StartTimerUseCase? _startTimerUseCase;
+  StopTimerUseCase? _stopTimerUseCase;
+  PauseTimerUseCase? _pauseTimerUseCase;
+  GetGroupDetailUseCase? _getGroupDetailUseCase;
+  GetGroupMembersUseCase? _getGroupMembersUseCase;
+  StreamGroupMemberTimerStatusUseCase? _streamGroupMemberTimerStatusUseCase;
 
   String _groupId = '';
   String? _currentUserId;
@@ -38,17 +38,22 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
   GroupDetailState build() {
     print('🏗️ GroupDetailNotifier build() 호출');
 
-    // 의존성 주입
-    _startTimerUseCase = ref.watch(startTimerUseCaseProvider);
-    _stopTimerUseCase = ref.watch(stopTimerUseCaseProvider);
-    _pauseTimerUseCase = ref.watch(pauseTimerUseCaseProvider);
-    _getGroupDetailUseCase = ref.watch(getGroupDetailUseCaseProvider);
-    _getGroupMembersUseCase = ref.watch(getGroupMembersUseCaseProvider);
-    _streamGroupMemberTimerStatusUseCase = ref.watch(
-      streamGroupMemberTimerStatusUseCaseProvider,
-    );
+    // 🔧 이미 초기화된 경우 skip (중복 초기화 방지)
+    if (_startTimerUseCase == null) {
+      // 의존성 주입
+      _startTimerUseCase = ref.watch(startTimerUseCaseProvider);
+      _stopTimerUseCase = ref.watch(stopTimerUseCaseProvider);
+      _pauseTimerUseCase = ref.watch(pauseTimerUseCaseProvider);
+      _getGroupDetailUseCase = ref.watch(getGroupDetailUseCaseProvider);
+      _getGroupMembersUseCase = ref.watch(getGroupMembersUseCaseProvider);
+      _streamGroupMemberTimerStatusUseCase = ref.watch(
+        streamGroupMemberTimerStatusUseCaseProvider,
+      );
 
-    // 🔧 현재 사용자 ID 가져오기
+      print('🔧 UseCase 의존성 주입 완료');
+    }
+
+    // 현재 사용자 ID 가져오기 (매번 업데이트될 수 있으므로 항상 확인)
     final currentUser = ref.watch(currentUserProvider);
     _currentUserId = currentUser?.uid;
 
@@ -147,7 +152,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     );
 
     // 새 타이머 세션 시작
-    await _startTimerUseCase.execute(_groupId);
+    await _startTimerUseCase?.execute(_groupId);
 
     // 타이머 시작
     _startTimerCountdown();
@@ -163,7 +168,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     // 🔧 즉시 멤버 리스트의 현재 사용자 상태 업데이트
     _updateCurrentUserInMemberList(isActive: false);
 
-    await _pauseTimerUseCase.execute(_groupId);
+    await _pauseTimerUseCase?.execute(_groupId);
   }
 
   // 🔧 타이머 재개 처리 - 멤버 리스트 즉시 업데이트 추가
@@ -194,7 +199,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     _localTimerStartTime = null;
 
     // 세션 종료
-    await _stopTimerUseCase.execute(_groupId);
+    await _stopTimerUseCase?.execute(_groupId);
 
     // 상태 업데이트
     state = state.copyWith(timerStatus: TimerStatus.stop);
@@ -250,9 +255,11 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     state = state.copyWith(groupMembersResult: const AsyncValue.loading());
 
     try {
-      final result = await _getGroupMembersUseCase.execute(_groupId);
-      state = state.copyWith(groupMembersResult: result);
-      print('✅ 최초 멤버 정보 로드 완료');
+      final result = await _getGroupMembersUseCase?.execute(_groupId);
+      if (result != null) {
+        state = state.copyWith(groupMembersResult: result);
+        print('✅ 최초 멤버 정보 로드 완료');
+      }
     } catch (e) {
       print('❌ 최초 멤버 정보 로드 실패: $e');
       state = state.copyWith(
@@ -268,7 +275,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     _timerStatusSubscription?.cancel();
 
     _timerStatusSubscription = _streamGroupMemberTimerStatusUseCase
-        .execute(_groupId)
+        ?.execute(_groupId)
         .listen(
           (asyncValue) {
             print('🔄 실시간 타이머 상태 업데이트 수신: ${asyncValue.runtimeType}');
@@ -302,12 +309,28 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     required bool isActive,
     DateTime? timerStartTime,
   }) {
-    if (_currentUserId == null) return;
+    if (_currentUserId == null) {
+      print('⚠️ 현재 사용자 ID가 없어서 멤버 리스트 업데이트를 건너뜁니다');
+      return;
+    }
 
     final currentMembersResult = state.groupMembersResult;
-    if (currentMembersResult is! AsyncData<List<GroupMember>>) return;
+    if (currentMembersResult is! AsyncData<List<GroupMember>>) {
+      print('⚠️ 멤버 리스트가 AsyncData 상태가 아니어서 업데이트를 건너뜁니다');
+      return;
+    }
 
     final currentMembers = currentMembersResult.value;
+    if (currentMembers.isEmpty) {
+      print('⚠️ 멤버 리스트가 null이어서 업데이트를 건너뜁니다');
+      return;
+    }
+
+    // 🔧 경과 시간을 더 정확하게 계산 (초 단위)
+    final int elapsedSeconds =
+        isActive && timerStartTime != null
+            ? DateTime.now().difference(timerStartTime).inSeconds
+            : 0;
 
     final updatedMembers =
         currentMembers.map((member) {
@@ -316,10 +339,8 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
             return member.copyWith(
               isActive: isActive,
               timerStartTime: timerStartTime,
-              elapsedMinutes:
-                  isActive && timerStartTime != null
-                      ? DateTime.now().difference(timerStartTime).inMinutes
-                      : 0,
+              // 🔧 elapsedMinutes 대신 실제 경과 시간을 분 단위로 정확히 계산
+              elapsedMinutes: (elapsedSeconds / 60).floor(),
             );
           }
           return member;
@@ -329,7 +350,9 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
       groupMembersResult: AsyncData(updatedMembers),
     );
 
-    print('🔧 현재 사용자 멤버 상태 즉시 업데이트: isActive=$isActive');
+    print(
+      '🔧 현재 사용자 멤버 상태 즉시 업데이트: isActive=$isActive, elapsedSeconds=$elapsedSeconds',
+    );
   }
 
   // 🔧 로컬 타이머 상태와 원격 데이터 병합 - 타입 안전성 수정
@@ -344,14 +367,16 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
 
     return remoteMembers.map((member) {
       if (member.userId == _currentUserId) {
-        // 현재 사용자는 로컬 상태로 덮어쓰기
+        // 🔧 현재 사용자는 로컬 상태로 덮어쓰기 (더 정확한 시간 계산)
+        final elapsedSeconds =
+            isLocalTimerActive && localStartTime != null
+                ? DateTime.now().difference(localStartTime).inSeconds
+                : 0;
+
         return member.copyWith(
           isActive: isLocalTimerActive,
           timerStartTime: localStartTime,
-          elapsedMinutes:
-              isLocalTimerActive && localStartTime != null
-                  ? DateTime.now().difference(localStartTime).inMinutes
-                  : 0,
+          elapsedMinutes: (elapsedSeconds / 60).floor(),
         );
       }
       // 다른 사용자는 원격 데이터 그대로 사용
@@ -375,7 +400,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     // 로컬 타이머 경과 시간 업데이트
     state = state.copyWith(elapsedSeconds: state.elapsedSeconds + 1);
 
-    // 🔧 멤버 리스트의 현재 사용자 경과 시간도 업데이트
+    // 🔧 멤버 리스트의 현재 사용자 경과 시간도 업데이트 (매초마다)
     if (_localTimerStartTime != null) {
       _updateCurrentUserInMemberList(
         isActive: true,
@@ -404,7 +429,9 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
   // 그룹 세부 정보 로드
   Future<void> _loadGroupDetail() async {
     state = state.copyWith(groupDetailResult: const AsyncValue.loading());
-    final result = await _getGroupDetailUseCase.execute(_groupId);
-    state = state.copyWith(groupDetailResult: result);
+    final result = await _getGroupDetailUseCase?.execute(_groupId);
+    if (result != null) {
+      state = state.copyWith(groupDetailResult: result);
+    }
   }
 }


### PR DESCRIPTION

## 🚀 주요 변경사항
- `StreamGroupMemberTimerStatusUseCase` 추가 및 DI 설정
- `GroupRepository` 및 `GroupDataSource`에 실시간 타이머 상태 스트림 관련 메서드 추가
- `GroupFirebaseDataSource` 및 `MockGroupDataSourceImpl`에 스트림 기능 구현
  - Firestore: `members` 컬렉션 변경 감지 및 관련 `timerActivities` 조회 후 병합하여 스트림
  - Mock: StreamController를 사용하여 타이머 활동 변경 시 알림
- `GroupFirebaseDataSource` 멤버 정보 캐싱 로직 개선
  - 그룹 ID 변경 시 캐시 무효화
  - 그룹 정보 변경 시 관련 캐시 무효화
- `GroupDetailNotifier`에서 기존 주기적 멤버 업데이트 로직을 실시간 스트림 구독으로 대체
  - 화면 진입 시 최초 한 번 멤버 정보 로드 후, 스트림을 통해 실시간 업데이트
  - 타이머 틱 이벤트에서 멤버 업데이트 로직 제거
  - 화면 이탈 시 스트림 구독 해제
- `fetchGroupTimerActivities`의 효율성 개선 (Firestore): 멤버별 최신 활동만 조회하도록 최적화

## 💬 참고/이슈 링크(선택)
- 관련 이슈: #337
- 참고사항/의논사항: 아직 해결 여부 확인 못했음
