### PR TITLE
[fix] 실시간 멤버 타이머 상태 동기화 및 표시 개선

### DIFF
--- a/lib/group/domain/model/group_member.dart
+++ b/lib/group/domain/model/group_member.dart
@@ -14,7 +14,8 @@ class GroupMember with _$GroupMember {
     required this.joinedAt,
     this.isActive = false, // 활동 상태 (활성/비활성)
     this.timerStartTime, // 현재 타이머 상태 (시작된 시간)
-    this.elapsedMinutes = 0, // 경과 시간 (분 단위)
+    this.elapsedMinutes = 0, // 경과 시간 (분 단위) - 기존 호환성 유지
+    this.elapsedSeconds = 0, // 🔧 새로 추가: 경과 시간 (초 단위)
   });
 
   final String id;
@@ -24,39 +25,71 @@ class GroupMember with _$GroupMember {
   final String role; // "owner", "member"
   final DateTime joinedAt;
 
-  // 추가된 필드
+  // 기존 필드들
   final bool isActive; // 활동 상태 (활성/비활성)
   final DateTime? timerStartTime; // 현재 타이머 상태 (시작된 시간)
-  final int elapsedMinutes; // 경과 시간 (분 단위)
+  final int elapsedMinutes; // 경과 시간 (분 단위) - 기존 호환성 유지
+
+  // 🔧 새로 추가된 필드
+  final int elapsedSeconds; // 경과 시간 (초 단위)
 
   // 관리자 여부 확인 헬퍼 메서드
   bool get isOwner => role == "owner";
 
-  // 경과 시간 문자열 포맷 (HH:MM:SS)
+  // 🔧 개선된 경과 시간 문자열 포맷 (초 단위 기반)
   String get elapsedTimeFormat {
-    // 초 단위로 변환
-    final seconds = elapsedMinutes * 60;
+    // elapsedSeconds 우선 사용, 없으면 elapsedMinutes * 60 사용 (하위 호환성)
+    final totalSeconds =
+        elapsedSeconds > 0 ? elapsedSeconds : elapsedMinutes * 60;
 
     // 시, 분, 초 계산
-    final hours = seconds ~/ 3600;
-    final minutes = (seconds % 3600) ~/ 60;
-    final remainingSeconds = seconds % 60;
+    final hours = totalSeconds ~/ 3600;
+    final minutes = (totalSeconds % 3600) ~/ 60;
+    final seconds = totalSeconds % 60;
 
     // HH:MM:SS 형식으로 반환
-    return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${remainingSeconds.toString().padLeft(2, '0')}';
+    return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
   }
 
-  // 현재 시간 기준 업데이트된 GroupMember 반환
+  // 🔧 현재 시간 기준 업데이트된 GroupMember 반환 (초 단위 기반)
   GroupMember updateElapsedTime() {
     if (!isActive || timerStartTime == null) {
       return this;
     }
 
-    // 시작 시간부터 현재까지의 경과 시간 계산
+    // 시작 시간부터 현재까지의 경과 시간 계산 (초 단위)
     final now = DateTime.now();
     final diff = now.difference(timerStartTime!);
-    final newElapsedMinutes = diff.inMinutes;
+    final newElapsedSeconds = diff.inSeconds;
 
-    return copyWith(elapsedMinutes: newElapsedMinutes);
+    return copyWith(
+      elapsedSeconds: newElapsedSeconds,
+      elapsedMinutes: (newElapsedSeconds / 60).floor(), // 호환성을 위해 분 단위도 업데이트
+    );
+  }
+
+  // 🔧 실시간 경과 시간을 초 단위로 계산하는 헬퍼 메서드
+  int get currentElapsedSeconds {
+    if (!isActive || timerStartTime == null) {
+      return elapsedSeconds;
+    }
+
+    // 현재 시간 기준으로 실시간 계산
+    final now = DateTime.now();
+    final diff = now.difference(timerStartTime!);
+    return diff.inSeconds;
+  }
+
+  // 🔧 실시간 경과 시간을 포맷된 문자열로 반환
+  String get currentElapsedTimeFormat {
+    final totalSeconds = currentElapsedSeconds;
+
+    // 시, 분, 초 계산
+    final hours = totalSeconds ~/ 3600;
+    final minutes = (totalSeconds % 3600) ~/ 60;
+    final seconds = totalSeconds % 60;
+
+    // HH:MM:SS 형식으로 반환
+    return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
   }
 }

--- a/lib/group/presentation/group_detail/group_detail_notifier.dart
+++ b/lib/group/presentation/group_detail/group_detail_notifier.dart
@@ -33,10 +33,12 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
   String _groupId = '';
   String? _currentUserId;
   DateTime? _localTimerStartTime;
+  bool mounted = true;
 
   @override
   GroupDetailState build() {
     print('🏗️ GroupDetailNotifier build() 호출');
+    mounted = true; // 🔧 mounted 상태 설정
 
     // 🔧 이미 초기화된 경우 skip (중복 초기화 방지)
     if (_startTimerUseCase == null) {
@@ -357,7 +359,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     );
   }
 
-  // 🔧 로컬 타이머 상태와 원격 데이터 병합 - elapsedSeconds 사용
+  // 🔧 로컬 타이머 상태와 원격 데이터 병합 + 타이머 상태 검증
   List<GroupMember> _mergeLocalTimerStateWithRemoteData(
     List<GroupMember> remoteMembers,
   ) {
@@ -369,22 +371,103 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
 
     return remoteMembers.map((member) {
       if (member.userId == _currentUserId) {
-        // 🔧 현재 사용자는 로컬 상태로 덮어쓰기 (초 단위로 정확히 계산)
+        // 🔧 현재 사용자: 서버 데이터와 로컬 상태 검증
+        final serverIsActive = member.isActive;
+        final serverStartTime = member.timerStartTime;
+
+        // 🔧 타이머 상태 검증 로직
+        if (_shouldValidateTimerState(
+          serverIsActive,
+          serverStartTime,
+          isLocalTimerActive,
+          localStartTime,
+        )) {
+          print('🔧 타이머 상태 불일치 감지 - 서버 상태로 동기화');
+
+          // 서버 상태가 비활성이고 로컬이 활성인 경우 → 로컬 타이머 중지
+          if (!serverIsActive && isLocalTimerActive) {
+            print('🔧 서버에서 타이머가 중지된 것을 감지 - 로컬 타이머 중지');
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted) {
+                _handleStopTimer();
+              }
+            });
+          }
+          // 서버 상태가 활성이고 로컬이 비활성인 경우 → 로컬 타이머 시작
+          else if (serverIsActive &&
+              !isLocalTimerActive &&
+              serverStartTime != null) {
+            print('🔧 서버에서 타이머가 시작된 것을 감지 - 로컬 타이머 동기화');
+            _localTimerStartTime = serverStartTime;
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted) {
+                state = state.copyWith(timerStatus: TimerStatus.running);
+                _startTimerCountdown();
+              }
+            });
+          }
+        }
+
+        // 🔧 로컬 상태 우선 사용 (더 정확한 시간 계산)
         final elapsedSeconds =
             isLocalTimerActive && localStartTime != null
                 ? DateTime.now().difference(localStartTime).inSeconds
-                : 0;
+                : (serverIsActive && serverStartTime != null
+                    ? DateTime.now().difference(serverStartTime).inSeconds
+                    : 0);
 
         return member.copyWith(
           isActive: isLocalTimerActive,
-          timerStartTime: localStartTime,
-          elapsedSeconds: elapsedSeconds, // 🔧 초 단위로 저장
-          elapsedMinutes: (elapsedSeconds / 60).floor(), // 호환성을 위해 분 단위도 저장
+          timerStartTime: localStartTime ?? serverStartTime,
+          elapsedSeconds: elapsedSeconds,
+          elapsedMinutes: (elapsedSeconds / 60).floor(),
         );
       }
-      // 다른 사용자는 원격 데이터 그대로 사용
-      return member;
+      // 🔧 다른 사용자: 서버 데이터 기반으로 실시간 시간 계산
+      else {
+        final elapsedSeconds =
+            member.isActive && member.timerStartTime != null
+                ? DateTime.now().difference(member.timerStartTime!).inSeconds
+                : member.elapsedSeconds;
+
+        return member.copyWith(
+          elapsedSeconds: elapsedSeconds,
+          elapsedMinutes: (elapsedSeconds / 60).floor(),
+        );
+      }
     }).toList();
+  }
+
+  // 🔧 타이머 상태 검증 필요 여부 판단
+  bool _shouldValidateTimerState(
+    bool serverIsActive,
+    DateTime? serverStartTime,
+    bool localIsActive,
+    DateTime? localStartTime,
+  ) {
+    // 1. 활성 상태가 다른 경우
+    if (serverIsActive != localIsActive) {
+      return true;
+    }
+
+    // 2. 둘 다 활성이지만 시작 시간이 크게 다른 경우 (5초 이상 차이)
+    if (serverIsActive &&
+        localIsActive &&
+        serverStartTime != null &&
+        localStartTime != null) {
+      final timeDifference = (serverStartTime.difference(localStartTime)).abs();
+      if (timeDifference.inSeconds > 5) {
+        print('🔧 타이머 시작 시간 차이 감지: ${timeDifference.inSeconds}초');
+        return true;
+      }
+    }
+
+    // 3. 서버에는 시작 시간이 있는데 로컬에는 없는 경우
+    if (serverIsActive && serverStartTime != null && localStartTime == null) {
+      return true;
+    }
+
+    return false;
   }
 
   // 타이머 시작

--- a/lib/group/presentation/group_detail/group_detail_notifier.dart
+++ b/lib/group/presentation/group_detail/group_detail_notifier.dart
@@ -304,7 +304,9 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
         );
   }
 
-  // 🔧 현재 사용자의 멤버 리스트 상태 즉시 업데이트 - null 안전성 추가
+  // group_detail_notifier.dart의 _updateCurrentUserInMemberList 메서드 부분만 수정
+
+  // 🔧 현재 사용자의 멤버 리스트 상태 즉시 업데이트 - elapsedSeconds 사용
   void _updateCurrentUserInMemberList({
     required bool isActive,
     DateTime? timerStartTime,
@@ -322,11 +324,11 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
 
     final currentMembers = currentMembersResult.value;
     if (currentMembers.isEmpty) {
-      print('⚠️ 멤버 리스트가 null이어서 업데이트를 건너뜁니다');
+      print('⚠️ 멤버 리스트가 비어있어서 업데이트를 건너뜁니다');
       return;
     }
 
-    // 🔧 경과 시간을 더 정확하게 계산 (초 단위)
+    // 🔧 경과 시간을 초 단위로 정확하게 계산
     final int elapsedSeconds =
         isActive && timerStartTime != null
             ? DateTime.now().difference(timerStartTime).inSeconds
@@ -335,12 +337,12 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     final updatedMembers =
         currentMembers.map((member) {
           if (member.userId == _currentUserId) {
-            // 현재 사용자의 상태만 업데이트
+            // 🔧 현재 사용자의 상태만 업데이트 (초 단위 사용)
             return member.copyWith(
               isActive: isActive,
               timerStartTime: timerStartTime,
-              // 🔧 elapsedMinutes 대신 실제 경과 시간을 분 단위로 정확히 계산
-              elapsedMinutes: (elapsedSeconds / 60).floor(),
+              elapsedSeconds: elapsedSeconds, // 🔧 초 단위로 저장
+              elapsedMinutes: (elapsedSeconds / 60).floor(), // 호환성을 위해 분 단위도 저장
             );
           }
           return member;
@@ -355,7 +357,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     );
   }
 
-  // 🔧 로컬 타이머 상태와 원격 데이터 병합 - 타입 안전성 수정
+  // 🔧 로컬 타이머 상태와 원격 데이터 병합 - elapsedSeconds 사용
   List<GroupMember> _mergeLocalTimerStateWithRemoteData(
     List<GroupMember> remoteMembers,
   ) {
@@ -367,7 +369,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
 
     return remoteMembers.map((member) {
       if (member.userId == _currentUserId) {
-        // 🔧 현재 사용자는 로컬 상태로 덮어쓰기 (더 정확한 시간 계산)
+        // 🔧 현재 사용자는 로컬 상태로 덮어쓰기 (초 단위로 정확히 계산)
         final elapsedSeconds =
             isLocalTimerActive && localStartTime != null
                 ? DateTime.now().difference(localStartTime).inSeconds
@@ -376,7 +378,8 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
         return member.copyWith(
           isActive: isLocalTimerActive,
           timerStartTime: localStartTime,
-          elapsedMinutes: (elapsedSeconds / 60).floor(),
+          elapsedSeconds: elapsedSeconds, // 🔧 초 단위로 저장
+          elapsedMinutes: (elapsedSeconds / 60).floor(), // 호환성을 위해 분 단위도 저장
         );
       }
       // 다른 사용자는 원격 데이터 그대로 사용

--- a/lib/group/presentation/group_detail/group_detail_notifier.dart
+++ b/lib/group/presentation/group_detail/group_detail_notifier.dart
@@ -64,6 +64,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
       print('🗑️ GroupDetailNotifier dispose - 타이머 및 스트림 정리');
       _timer?.cancel();
       _timerStatusSubscription?.cancel();
+      mounted = false; // 🔧 mounted 상태 해제
     });
 
     return const GroupDetailState();

--- a/lib/group/presentation/group_detail/group_detail_screen.dart
+++ b/lib/group/presentation/group_detail/group_detail_screen.dart
@@ -1,4 +1,6 @@
 // lib/group/presentation/group_detail/group_detail_screen.dart
+import 'dart:async';
+
 import 'package:devlink_mobile_app/core/component/app_image.dart';
 import 'package:devlink_mobile_app/core/styles/app_color_styles.dart';
 import 'package:devlink_mobile_app/core/styles/app_text_styles.dart';
@@ -33,11 +35,17 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
   bool _isTimerVisible = true;
   bool _isMessageExpanded = false;
 
+  // 🔧 실시간 멤버 타이머 업데이트를 위한 Timer 추가
+  Timer? _memberTimerUpdateTimer;
+
   @override
   void initState() {
     super.initState();
     _scrollController = ScrollController();
     _scrollController.addListener(_onScroll);
+
+    // 🔧 멤버 타이머 실시간 업데이트 시작
+    _startMemberTimerUpdates();
   }
 
   @override
@@ -72,10 +80,38 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
     }
   }
 
+  // 🔧 멤버 타이머 실시간 업데이트 시작
+  void _startMemberTimerUpdates() {
+    _memberTimerUpdateTimer?.cancel();
+    _memberTimerUpdateTimer = Timer.periodic(
+      const Duration(seconds: 1),
+      (_) {
+        // 활성 멤버가 있는 경우에만 UI 업데이트
+        final members = _extractMembersData();
+        final hasActiveMembers = members.any((member) => member.isActive);
+
+        if (hasActiveMembers && mounted) {
+          setState(() {
+            // UI 업데이트를 위한 setState
+            // 실제 데이터는 GroupMember의 currentElapsedTimeFormat에서 실시간 계산됨
+          });
+        }
+      },
+    );
+  }
+
+  // 🔧 멤버 타이머 업데이트 중지
+  void _stopMemberTimerUpdates() {
+    _memberTimerUpdateTimer?.cancel();
+    _memberTimerUpdateTimer = null;
+  }
+
   @override
   void dispose() {
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
+    // 🔧 멤버 타이머 업데이트 정리
+    _stopMemberTimerUpdates();
     super.dispose();
   }
 
@@ -336,7 +372,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
     );
   }
 
-  // 🔧 개별 멤버 아이템 - 실시간 시간 표시 개선
+  // 🔧 개별 멤버 아이템 - 실시간 시간 표시
   Widget _buildMemberItem(GroupMember member) {
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -399,7 +435,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
         ),
         const SizedBox(height: 8),
 
-        // 🔧 타이머 표시 - 실시간 시간 사용
+        // 🔧 타이머 표시 - 실시간 계산 사용
         member.isActive
             ? Container(
               padding: const EdgeInsets.symmetric(
@@ -411,7 +447,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
                 borderRadius: BorderRadius.circular(10),
               ),
               child: Text(
-                member.currentElapsedTimeFormat, // 🔧 실시간 시간 포맷 사용
+                member.currentElapsedTimeFormat, // 🔧 실시간 시간 계산 사용
                 style: TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.bold,

--- a/lib/group/presentation/group_detail/group_detail_screen.dart
+++ b/lib/group/presentation/group_detail/group_detail_screen.dart
@@ -336,7 +336,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
     );
   }
 
-  // 🔥 순수 UI: 개별 멤버 아이템
+  // 🔧 개별 멤버 아이템 - 실시간 시간 표시 개선
   Widget _buildMemberItem(GroupMember member) {
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -399,7 +399,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
         ),
         const SizedBox(height: 8),
 
-        // 타이머 표시
+        // 🔧 타이머 표시 - 실시간 시간 사용
         member.isActive
             ? Container(
               padding: const EdgeInsets.symmetric(
@@ -411,7 +411,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
                 borderRadius: BorderRadius.circular(10),
               ),
               child: Text(
-                member.elapsedTimeFormat,
+                member.currentElapsedTimeFormat, // 🔧 실시간 시간 포맷 사용
                 style: TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.bold,


### PR DESCRIPTION
## 🚀 주요 변경사항
- 데이터 소스:
    - `streamGroupMemberTimerStatus`가 DTO를 반환하도록 수정 (멤버 정보 + 최신 타이머 활동)
    - 멤버 정보와 타이머 상태를 결합하는 헬퍼 메서드 추가
- 리포지토리:
    - `streamGroupMemberTimerStatus`에서 기존 Mapper를 활용하여 DTO를 도메인 모델로 변환
- Notifier:
    - 로컬 타이머 상태와 서버 데이터를 병합하고, 불일치 시 서버 상태로 동기화하는 로직 추가
    - 타이머 상태 검증 로직 (`_shouldValidateTimerState`) 추가
    - `mounted` 상태를 사용하여 위젯이 해제된 후 `setState` 호출 방지
- 화면:
    - `Timer`를 사용하여 1초마다 활성 멤버의 타이머 UI를 업데이트
    - `dispose` 시 `Timer` 정리
    - 멤버 아이템의 타이머 표시에 실시간으로 계산된 시간(`currentElapsedTimeFormat`) 사용



## 💬 참고/이슈 링크(선택)
- 관련 이슈: #337 
- 참고사항/의논사항: 테스트 필요함. 
