### PR TITLE
[fix] 그룹 상세화면 안정성 및 알림 기능 추가

### DIFF
--- a/lib/group/presentation/group_detail/group_detail_notifier.dart
+++ b/lib/group/presentation/group_detail/group_detail_notifier.dart
@@ -22,7 +22,11 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
   Timer? _timer;
   StreamSubscription? _timerStatusSubscription;
 
-  // 🔧 late 필드를 nullable로 변경하여 중복 초기화 문제 해결
+  // 🔧 새로 추가: 재연결 관리
+  Timer? _reconnectionTimer;
+  Timer? _healthCheckTimer;
+
+  // UseCase 의존성들
   StartTimerUseCase? _startTimerUseCase;
   StopTimerUseCase? _stopTimerUseCase;
   PauseTimerUseCase? _pauseTimerUseCase;
@@ -38,11 +42,9 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
   @override
   GroupDetailState build() {
     print('🏗️ GroupDetailNotifier build() 호출');
-    mounted = true; // 🔧 mounted 상태 설정
+    mounted = true;
 
-    // 🔧 이미 초기화된 경우 skip (중복 초기화 방지)
     if (_startTimerUseCase == null) {
-      // 의존성 주입
       _startTimerUseCase = ref.watch(startTimerUseCaseProvider);
       _stopTimerUseCase = ref.watch(stopTimerUseCaseProvider);
       _pauseTimerUseCase = ref.watch(pauseTimerUseCaseProvider);
@@ -55,19 +57,93 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
       print('🔧 UseCase 의존성 주입 완료');
     }
 
-    // 현재 사용자 ID 가져오기 (매번 업데이트될 수 있으므로 항상 확인)
     final currentUser = ref.watch(currentUserProvider);
     _currentUserId = currentUser?.uid;
 
-    // 화면 이탈 시 타이머 및 스트림 정리
     ref.onDispose(() {
-      print('🗑️ GroupDetailNotifier dispose - 타이머 및 스트림 정리');
-      _timer?.cancel();
-      _timerStatusSubscription?.cancel();
-      mounted = false; // 🔧 mounted 상태 해제
+      print('🗑️ GroupDetailNotifier dispose - 모든 리소스 정리');
+      _cleanupAllTimers();
+      mounted = false;
     });
 
     return const GroupDetailState();
+  }
+
+  // 🔧 새로운 메서드: 모든 타이머 정리
+  void _cleanupAllTimers() {
+    _timer?.cancel();
+    _timer = null;
+
+    _timerStatusSubscription?.cancel();
+    _timerStatusSubscription = null;
+
+    _reconnectionTimer?.cancel();
+    _reconnectionTimer = null;
+
+    _healthCheckTimer?.cancel();
+    _healthCheckTimer = null;
+  }
+
+  // 🔧 새로운 메서드: 화면 활성 상태 관리
+  void setScreenActive(bool isActive) {
+    if (state.isScreenActive == isActive) return;
+
+    print('📱 화면 활성 상태 변경: ${state.isScreenActive} -> $isActive');
+
+    state = state.copyWith(isScreenActive: isActive);
+
+    if (_groupId.isNotEmpty) {
+      _updateStreamSubscription();
+    }
+  }
+
+  // 🔧 새로운 메서드: 앱 포그라운드 상태 관리
+  void setAppForeground(bool isForeground) {
+    if (state.isAppInForeground == isForeground) return;
+
+    print('🌅 앱 포그라운드 상태 변경: ${state.isAppInForeground} -> $isForeground');
+
+    state = state.copyWith(isAppInForeground: isForeground);
+
+    if (_groupId.isNotEmpty) {
+      _updateStreamSubscription();
+    }
+  }
+
+  // 🔧 새로운 메서드: 스트림 구독 상태 업데이트
+  void _updateStreamSubscription() {
+    final shouldBeActive = state.isActive && mounted;
+    final isCurrentlyActive = _timerStatusSubscription != null;
+
+    print(
+      '🔄 스트림 구독 상태 확인: shouldBeActive=$shouldBeActive, isCurrentlyActive=$isCurrentlyActive',
+    );
+
+    if (shouldBeActive && !isCurrentlyActive) {
+      _startRealTimeTimerStatusStream();
+    } else if (!shouldBeActive && isCurrentlyActive) {
+      _stopRealTimeTimerStatusStream();
+    }
+  }
+
+  // 🔧 새로운 메서드: 실시간 스트림 정지
+  void _stopRealTimeTimerStatusStream() {
+    print('🔴 실시간 타이머 상태 스트림 정지');
+
+    _timerStatusSubscription?.cancel();
+    _timerStatusSubscription = null;
+
+    _reconnectionTimer?.cancel();
+    _reconnectionTimer = null;
+
+    _healthCheckTimer?.cancel();
+    _healthCheckTimer = null;
+
+    // 🔧 스트림 상태 업데이트
+    state = state.copyWith(
+      streamConnectionStatus: StreamConnectionStatus.disconnected,
+      reconnectionAttempts: 0,
+    );
   }
 
   // 화면 재진입 시 데이터 갱신
@@ -77,11 +153,21 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
       return;
     }
 
-    print('🔄 화면 재진입 감지 - 데이터 새로고침 시작');
+    print('🔄 화면 재진입 감지 - 상태 복원 및 데이터 새로고침');
+
+    // 화면 활성 상태로 설정
+    setScreenActive(true);
+
+    // 에러 메시지 및 재연결 시도 횟수 초기화
+    state = state.copyWith(
+      errorMessage: null,
+      reconnectionAttempts: 0,
+    );
+
     await refreshAllData();
   }
 
-  // 액션 처리
+  // 액션 처리 (기존 로직 유지)
   Future<void> onAction(GroupDetailAction action) async {
     switch (action) {
       case StartTimer():
@@ -134,56 +220,43 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     }
   }
 
-  // 🔧 타이머 시작 처리 - 멤버 리스트 즉시 업데이트 추가
+  // 🔧 타이머 시작 처리 (기존 로직 유지)
   Future<void> _handleStartTimer() async {
     if (state.timerStatus == TimerStatus.running) return;
 
-    // 로컬 타이머 시작 시간 기록
     _localTimerStartTime = DateTime.now();
 
-    // 타이머 상태 및 경과 시간 초기화
     state = state.copyWith(
       timerStatus: TimerStatus.running,
       errorMessage: null,
       elapsedSeconds: 0,
     );
 
-    // 🔧 즉시 멤버 리스트의 현재 사용자 상태 업데이트
     _updateCurrentUserInMemberList(
       isActive: true,
       timerStartTime: _localTimerStartTime,
     );
 
-    // 새 타이머 세션 시작
     await _startTimerUseCase?.execute(_groupId);
-
-    // 타이머 시작
     _startTimerCountdown();
   }
 
-  // 🔧 타이머 일시정지 처리 - 멤버 리스트 즉시 업데이트 추가
   Future<void> _handlePauseTimer() async {
     if (state.timerStatus != TimerStatus.running) return;
 
     _timer?.cancel();
     state = state.copyWith(timerStatus: TimerStatus.paused);
 
-    // 🔧 즉시 멤버 리스트의 현재 사용자 상태 업데이트
     _updateCurrentUserInMemberList(isActive: false);
-
     await _pauseTimerUseCase?.execute(_groupId);
   }
 
-  // 🔧 타이머 재개 처리 - 멤버 리스트 즉시 업데이트 추가
   void _handleResumeTimer() {
     if (state.timerStatus != TimerStatus.paused) return;
 
-    // 타이머 재개 시점 기록
     _localTimerStartTime = DateTime.now();
-
     state = state.copyWith(timerStatus: TimerStatus.running);
 
-    // 🔧 즉시 멤버 리스트의 현재 사용자 상태 업데이트
     _updateCurrentUserInMemberList(
       isActive: true,
       timerStartTime: _localTimerStartTime,
@@ -192,33 +265,23 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     _startTimerCountdown();
   }
 
-  // 🔧 타이머 종료 처리 - 멤버 리스트 즉시 업데이트 추가
   Future<void> _handleStopTimer() async {
-    if (state.timerStatus == TimerStatus.stop) {
-      return;
-    }
+    if (state.timerStatus == TimerStatus.stop) return;
 
     _timer?.cancel();
     _localTimerStartTime = null;
 
-    // 세션 종료
     await _stopTimerUseCase?.execute(_groupId);
 
-    // 상태 업데이트
     state = state.copyWith(timerStatus: TimerStatus.stop);
-
-    // 🔧 즉시 멤버 리스트의 현재 사용자 상태 업데이트
     _updateCurrentUserInMemberList(isActive: false);
   }
 
-  // 🔧 타이머 초기화 처리 - 멤버 리스트 즉시 업데이트 추가
   Future<void> _handleResetTimer() async {
     _timer?.cancel();
     _localTimerStartTime = null;
 
     state = state.copyWith(timerStatus: TimerStatus.stop, elapsedSeconds: 0);
-
-    // 🔧 즉시 멤버 리스트의 현재 사용자 상태 업데이트
     _updateCurrentUserInMemberList(isActive: false);
   }
 
@@ -226,7 +289,6 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
   Future<void> _handleSetGroupId(String groupId) async {
     print('📊 Setting group ID in notifier: $groupId');
     _groupId = groupId;
-
     await _loadInitialData();
   }
 
@@ -242,7 +304,8 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
         _loadInitialGroupMembers(),
       ], eagerError: false);
 
-      _startRealTimeTimerStatusStream();
+      // 🔧 스트림 구독 상태 업데이트
+      _updateStreamSubscription();
 
       print('✅ 초기 데이터 로드 완료');
     } catch (e, s) {
@@ -271,45 +334,150 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     }
   }
 
-  // 🔧 실시간 타이머 상태 스트림 시작 - 타입 안전성 수정
+  // 🔧 개선된 실시간 스트림 시작
   void _startRealTimeTimerStatusStream() {
+    if (_timerStatusSubscription != null) {
+      print('⚠️ 이미 활성화된 스트림이 있어서 시작을 건너뜁니다');
+      return;
+    }
+
     print('🔴 실시간 타이머 상태 스트림 시작');
 
-    _timerStatusSubscription?.cancel();
+    // 🔧 스트림 상태를 연결 중으로 설정
+    state = state.copyWith(
+      streamConnectionStatus: StreamConnectionStatus.connecting,
+      errorMessage: null,
+    );
 
     _timerStatusSubscription = _streamGroupMemberTimerStatusUseCase
         ?.execute(_groupId)
         .listen(
           (asyncValue) {
-            print('🔄 실시간 타이머 상태 업데이트 수신: ${asyncValue.runtimeType}');
-
-            switch (asyncValue) {
-              case AsyncData(:final value):
-                // 🔧 타입 안전성 확보 및 로컬 상태와 병합
-                final mergedMembers = _mergeLocalTimerStateWithRemoteData(
-                  value,
-                );
-                state = state.copyWith(
-                  groupMembersResult: AsyncData(mergedMembers),
-                );
-                print('✅ 실시간 멤버 상태 업데이트 완료 (${mergedMembers.length}명)');
-
-              case AsyncError(:final error):
-                print('⚠️ 실시간 스트림 에러 (기존 상태 유지): $error');
-
-              case AsyncLoading():
-                print('🔄 실시간 스트림 로딩 중 (상태 유지)');
+            if (!mounted || !state.isActive) {
+              print('🔇 화면 비활성 상태로 스트림 데이터 무시');
+              return;
             }
+
+            _handleStreamData(asyncValue);
           },
           onError: (error) {
             print('❌ 실시간 스트림 구독 에러: $error');
+            _handleStreamError(error);
+          },
+          onDone: () {
+            print('✅ 실시간 스트림 완료');
+            _timerStatusSubscription = null;
+            state = state.copyWith(
+              streamConnectionStatus: StreamConnectionStatus.disconnected,
+            );
           },
         );
+
+    // 🔧 스트림 헬스 체크 시작
+    _startStreamHealthCheck();
   }
 
-  // group_detail_notifier.dart의 _updateCurrentUserInMemberList 메서드 부분만 수정
+  // 🔧 새로운 메서드: 스트림 헬스 체크
+  void _startStreamHealthCheck() {
+    _healthCheckTimer?.cancel();
+    _healthCheckTimer = Timer.periodic(
+      const Duration(minutes: 2), // 2분마다 헬스 체크
+      (_) {
+        if (!mounted || !state.isActive) return;
 
-  // 🔧 현재 사용자의 멤버 리스트 상태 즉시 업데이트 - elapsedSeconds 사용
+        final isHealthy = state.isStreamHealthy;
+        print('💓 스트림 헬스 체크: ${isHealthy ? '정상' : '비정상'}');
+
+        if (!isHealthy &&
+            state.streamConnectionStatus == StreamConnectionStatus.connected) {
+          // 연결은 되어있지만 데이터가 오지 않는 상태
+          state = state.copyWith(
+            errorMessage: '실시간 업데이트가 지연되고 있습니다.',
+          );
+        }
+      },
+    );
+  }
+
+  // 🔧 새로운 메서드: 스트림 데이터 처리
+  void _handleStreamData(AsyncValue<List<GroupMember>> asyncValue) {
+    print('🔄 실시간 타이머 상태 업데이트 수신: ${asyncValue.runtimeType}');
+
+    switch (asyncValue) {
+      case AsyncData(:final value):
+        final mergedMembers = _mergeLocalTimerStateWithRemoteData(value);
+
+        // 🔧 스트림 상태 업데이트
+        state = state.copyWith(
+          groupMembersResult: AsyncData(mergedMembers),
+          streamConnectionStatus: StreamConnectionStatus.connected,
+          lastStreamUpdateTime: DateTime.now(),
+          errorMessage: null,
+          reconnectionAttempts: 0,
+        );
+
+        print('✅ 실시간 멤버 상태 업데이트 완료 (${mergedMembers.length}명)');
+
+      case AsyncError(:final error):
+        print('⚠️ 실시간 스트림 데이터 에러: $error');
+        _handleStreamError(error);
+
+      case AsyncLoading():
+        print('🔄 실시간 스트림 로딩 중');
+      // 로딩 상태는 특별한 처리 없이 유지
+    }
+  }
+
+  // 🔧 새로운 메서드: 스트림 에러 처리
+  void _handleStreamError(Object error) {
+    if (!mounted || !state.isActive) {
+      print('🔇 화면 비활성 상태로 에러 처리 건너뜀');
+      return;
+    }
+
+    // 🔧 스트림 상태를 실패로 업데이트
+    state = state.copyWith(
+      streamConnectionStatus: StreamConnectionStatus.failed,
+      errorMessage: '실시간 업데이트 연결에 문제가 발생했습니다.',
+    );
+
+    // 🔧 재연결 시도 (3회 제한)
+    if (state.shouldAttemptReconnection) {
+      _scheduleReconnection();
+    }
+  }
+
+  // 🔧 새로운 메서드: 재연결 스케줄링
+  void _scheduleReconnection() {
+    final currentAttempts = state.reconnectionAttempts;
+    final newAttempts = currentAttempts + 1;
+
+    print('🔄 재연결 스케줄링: $newAttempts/3');
+
+    state = state.copyWith(
+      reconnectionAttempts: newAttempts,
+      streamConnectionStatus: StreamConnectionStatus.disconnected,
+    );
+
+    _reconnectionTimer?.cancel();
+    _reconnectionTimer = Timer(
+      Duration(seconds: 2 * newAttempts), // 2초, 4초, 6초 간격
+      () {
+        if (!mounted || !state.isActive) return;
+
+        print('🔄 재연결 시도 실행: $newAttempts/3');
+
+        // 기존 구독 정리
+        _timerStatusSubscription?.cancel();
+        _timerStatusSubscription = null;
+
+        // 새 스트림 시작
+        _startRealTimeTimerStatusStream();
+      },
+    );
+  }
+
+  // 기존 메서드들 (로직 유지)
   void _updateCurrentUserInMemberList({
     required bool isActive,
     DateTime? timerStartTime,
@@ -331,7 +499,6 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
       return;
     }
 
-    // 🔧 경과 시간을 초 단위로 정확하게 계산
     final int elapsedSeconds =
         isActive && timerStartTime != null
             ? DateTime.now().difference(timerStartTime).inSeconds
@@ -340,12 +507,11 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     final updatedMembers =
         currentMembers.map((member) {
           if (member.userId == _currentUserId) {
-            // 🔧 현재 사용자의 상태만 업데이트 (초 단위 사용)
             return member.copyWith(
               isActive: isActive,
               timerStartTime: timerStartTime,
-              elapsedSeconds: elapsedSeconds, // 🔧 초 단위로 저장
-              elapsedMinutes: (elapsedSeconds / 60).floor(), // 호환성을 위해 분 단위도 저장
+              elapsedSeconds: elapsedSeconds,
+              elapsedMinutes: (elapsedSeconds / 60).floor(),
             );
           }
           return member;
@@ -360,23 +526,19 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     );
   }
 
-  // 🔧 로컬 타이머 상태와 원격 데이터 병합 + 타이머 상태 검증
   List<GroupMember> _mergeLocalTimerStateWithRemoteData(
     List<GroupMember> remoteMembers,
   ) {
     if (_currentUserId == null) return remoteMembers;
 
-    // 현재 로컬 타이머 상태 확인
     final isLocalTimerActive = state.timerStatus == TimerStatus.running;
     final localStartTime = _localTimerStartTime;
 
     return remoteMembers.map((member) {
       if (member.userId == _currentUserId) {
-        // 🔧 현재 사용자: 서버 데이터와 로컬 상태 검증
         final serverIsActive = member.isActive;
         final serverStartTime = member.timerStartTime;
 
-        // 🔧 타이머 상태 검증 로직
         if (_shouldValidateTimerState(
           serverIsActive,
           serverStartTime,
@@ -385,7 +547,6 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
         )) {
           print('🔧 타이머 상태 불일치 감지 - 서버 상태로 동기화');
 
-          // 서버 상태가 비활성이고 로컬이 활성인 경우 → 로컬 타이머 중지
           if (!serverIsActive && isLocalTimerActive) {
             print('🔧 서버에서 타이머가 중지된 것을 감지 - 로컬 타이머 중지');
             WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -393,9 +554,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
                 _handleStopTimer();
               }
             });
-          }
-          // 서버 상태가 활성이고 로컬이 비활성인 경우 → 로컬 타이머 시작
-          else if (serverIsActive &&
+          } else if (serverIsActive &&
               !isLocalTimerActive &&
               serverStartTime != null) {
             print('🔧 서버에서 타이머가 시작된 것을 감지 - 로컬 타이머 동기화');
@@ -409,7 +568,6 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
           }
         }
 
-        // 🔧 로컬 상태 우선 사용 (더 정확한 시간 계산)
         final elapsedSeconds =
             isLocalTimerActive && localStartTime != null
                 ? DateTime.now().difference(localStartTime).inSeconds
@@ -423,9 +581,7 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
           elapsedSeconds: elapsedSeconds,
           elapsedMinutes: (elapsedSeconds / 60).floor(),
         );
-      }
-      // 🔧 다른 사용자: 서버 데이터 기반으로 실시간 시간 계산
-      else {
+      } else {
         final elapsedSeconds =
             member.isActive && member.timerStartTime != null
                 ? DateTime.now().difference(member.timerStartTime!).inSeconds
@@ -439,19 +595,16 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     }).toList();
   }
 
-  // 🔧 타이머 상태 검증 필요 여부 판단
   bool _shouldValidateTimerState(
     bool serverIsActive,
     DateTime? serverStartTime,
     bool localIsActive,
     DateTime? localStartTime,
   ) {
-    // 1. 활성 상태가 다른 경우
     if (serverIsActive != localIsActive) {
       return true;
     }
 
-    // 2. 둘 다 활성이지만 시작 시간이 크게 다른 경우 (5초 이상 차이)
     if (serverIsActive &&
         localIsActive &&
         serverStartTime != null &&
@@ -463,7 +616,6 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
       }
     }
 
-    // 3. 서버에는 시작 시간이 있는데 로컬에는 없는 경우
     if (serverIsActive && serverStartTime != null && localStartTime == null) {
       return true;
     }
@@ -471,7 +623,6 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     return false;
   }
 
-  // 타이머 시작
   void _startTimerCountdown() {
     _timer?.cancel();
     _timer = Timer.periodic(
@@ -480,14 +631,11 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     );
   }
 
-  // 🔧 타이머 틱 이벤트 처리 - 멤버 리스트의 현재 사용자 시간도 업데이트
   void _handleTimerTick() {
     if (state.timerStatus != TimerStatus.running) return;
 
-    // 로컬 타이머 경과 시간 업데이트
     state = state.copyWith(elapsedSeconds: state.elapsedSeconds + 1);
 
-    // 🔧 멤버 리스트의 현재 사용자 경과 시간도 업데이트 (매초마다)
     if (_localTimerStartTime != null) {
       _updateCurrentUserInMemberList(
         isActive: true,
@@ -496,7 +644,6 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     }
   }
 
-  // 데이터 새로고침
   Future<void> refreshAllData() async {
     if (_groupId.isEmpty) return;
 
@@ -504,7 +651,9 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
 
     try {
       await _loadGroupDetail();
-      _startRealTimeTimerStatusStream();
+
+      // 🔧 스트림 구독 상태 업데이트
+      _updateStreamSubscription();
 
       print('✅ 데이터 새로고침 완료');
     } catch (e, s) {
@@ -513,7 +662,6 @@ class GroupDetailNotifier extends _$GroupDetailNotifier {
     }
   }
 
-  // 그룹 세부 정보 로드
   Future<void> _loadGroupDetail() async {
     state = state.copyWith(groupDetailResult: const AsyncValue.loading());
     final result = await _getGroupDetailUseCase?.execute(_groupId);

--- a/lib/group/presentation/group_detail/group_detail_screen_root.dart
+++ b/lib/group/presentation/group_detail/group_detail_screen_root.dart
@@ -269,15 +269,13 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
             currentState.elapsedSeconds == 0) {
           // 현재 stop 상태이고 경과시간이 0이면 백그라운드에서 강제 종료된 것으로 추정
           // 하지만 이것만으로는 정확한 판단이 어려움
-
-          // 🔧 일단 메시지 제거하고, 필요하면 별도 플래그 추가 검토
-          // ScaffoldMessenger.of(context).showSnackBar(
-          //   const SnackBar(
-          //     content: Text('앱이 백그라운드에 있는 동안 타이머가 종료되었습니다.'),
-          //     duration: Duration(seconds: 3),
-          //     backgroundColor: Colors.orange,
-          //   ),
-          // );
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('앱이 백그라운드에 있는 동안 타이머가 종료되었습니다.'),
+              duration: Duration(seconds: 3),
+              backgroundColor: Colors.orange,
+            ),
+          );
         }
       }
     });

--- a/lib/group/presentation/group_detail/group_detail_screen_root.dart
+++ b/lib/group/presentation/group_detail/group_detail_screen_root.dart
@@ -28,7 +28,7 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
   bool _wasInBackground = false;
   bool _isInitializing = false;
 
-  // 🔧 새로 추가: 상태 메시지 표시 관리
+  // 🔧 상태 메시지 표시 관리
   String? _lastShownStatusMessage;
   DateTime? _lastStatusMessageTime;
 
@@ -45,7 +45,7 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
 
   @override
   void dispose() {
-    // 🔧 개선: dispose 시 화면 비활성 상태 알림
+    // 🔧 dispose 시 화면 비활성 상태 알림
     if (_isInitialized) {
       print('🔄 화면 dispose - Notifier에 비활성 상태 알림');
       final notifier = ref.read(groupDetailNotifierProvider.notifier);
@@ -74,14 +74,38 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
           print('📱 앱이 백그라운드로 전환됨');
           _wasInBackground = true;
 
-          // 🔧 Notifier에 포그라운드 상태 변경 알림
           notifier.setAppForeground(false);
 
-          // 타이머 실행 중이면 중지
+          // 🔧 백그라운드 진입 시 타이머 강제 종료 처리
+          if (mounted) {
+            notifier.handleBackgroundTransition();
+          }
+        }
+        break;
+
+      case AppLifecycleState.inactive:
+        // 🔧 일시적 비활성 상태에서도 준비
+        if (_isInitialized && !_wasInBackground) {
+          print('📱 앱이 일시적으로 비활성화됨');
+          notifier.setAppForeground(false);
+        }
+        break;
+
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+        // 🔧 앱 종료 시에도 동일한 처리 (더 빠르게)
+        print('🔄 앱 종료 감지: $state');
+        if (_isInitialized) {
+          notifier.setAppForeground(false);
+          notifier.setScreenActive(false);
+
+          // 🔧 앱 종료 시에도 백그라운드 처리와 동일하게 타이머 종료
+          // 하지만 더 빠르게 처리해야 함
           if (mounted) {
             final currentState = ref.read(groupDetailNotifierProvider);
             if (currentState.timerStatus == TimerStatus.running) {
-              notifier.onAction(const GroupDetailAction.stopTimer());
+              print('⚡ 앱 종료 - 긴급 타이머 종료 처리');
+              notifier.handleBackgroundTransition();
             }
           }
         }
@@ -91,7 +115,6 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
         if (_wasInBackground && mounted && _isInitialized && !_isInitializing) {
           print('🔄 백그라운드에서 앱 재개 - 데이터 갱신');
 
-          // 🔧 Notifier에 포그라운드 상태 변경 알림
           notifier.setAppForeground(true);
 
           WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -102,24 +125,6 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
           });
         }
         _wasInBackground = false;
-        break;
-
-      case AppLifecycleState.inactive:
-        // 🔧 추가: 일시적 비활성 상태 (전화 수신, 알림 패널 등)
-        if (_isInitialized && !_wasInBackground) {
-          print('📱 앱이 일시적으로 비활성화됨');
-          notifier.setAppForeground(false);
-        }
-        break;
-
-      case AppLifecycleState.detached:
-      case AppLifecycleState.hidden:
-        print('🔄 생명주기 상태 변경: $state');
-        // 앱이 완전히 종료되거나 숨겨진 상태
-        if (_isInitialized) {
-          notifier.setAppForeground(false);
-          notifier.setScreenActive(false);
-        }
         break;
     }
   }
@@ -146,7 +151,7 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
     print('✅ 화면 초기화 완료');
   }
 
-  // 🔧 새로운 메서드: 상태 메시지 처리
+  // 🔧 상태 메시지 처리
   void _handleStatusMessage(String? statusMessage) {
     if (statusMessage == null || statusMessage.isEmpty) return;
 
@@ -254,24 +259,31 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
     }
   }
 
-  // 🔥 Root 역할: context 기반 작업 (메시지 표시)
+  // 🔥 Root 역할: context 기반 작업 (앱 재개 메시지)
   void _showAppResumedMessage() {
     Future.delayed(const Duration(milliseconds: 100), () {
       if (mounted) {
         final currentState = ref.read(groupDetailNotifierProvider);
-        if (currentState.timerStatus == TimerStatus.stop) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('앱이 백그라운드에 있는 동안 타이머가 중지되었습니다.'),
-              duration: Duration(seconds: 3),
-            ),
-          );
+        // 🔧 실제로 타이머가 실행 중이었고 백그라운드에서 종료된 경우만 메시지 표시
+        if (currentState.timerStatus == TimerStatus.stop &&
+            currentState.elapsedSeconds == 0) {
+          // 현재 stop 상태이고 경과시간이 0이면 백그라운드에서 강제 종료된 것으로 추정
+          // 하지만 이것만으로는 정확한 판단이 어려움
+
+          // 🔧 일단 메시지 제거하고, 필요하면 별도 플래그 추가 검토
+          // ScaffoldMessenger.of(context).showSnackBar(
+          //   const SnackBar(
+          //     content: Text('앱이 백그라운드에 있는 동안 타이머가 종료되었습니다.'),
+          //     duration: Duration(seconds: 3),
+          //     backgroundColor: Colors.orange,
+          //   ),
+          // );
         }
       }
     });
   }
 
-  // 🔥 Root 역할: context 기반 작업 (경고창)
+  // 🔥 Root 역할: context 기반 작업 (네비게이션 경고창)
   Future<bool> _showNavigationWarningDialog(BuildContext context) async {
     if (mounted) {
       return await showDialog<bool>(
@@ -302,6 +314,7 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
       final shouldNavigate = await _showNavigationWarningDialog(context);
 
       if (shouldNavigate && mounted) {
+        // 🔧 경고창에서 확인 시 타이머 종료
         await notifier.onAction(const GroupDetailAction.stopTimer());
 
         // 🔧 네비게이션 전 화면 비활성 상태 알림
@@ -364,7 +377,7 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
     final state = ref.watch(groupDetailNotifierProvider);
     final notifier = ref.read(groupDetailNotifierProvider.notifier);
 
-    // 🔧 새로 추가: 상태 메시지 처리
+    // 🔧 상태 메시지 처리
     final statusMessage = state.statusMessage;
     if (statusMessage != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -414,7 +427,7 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
       );
     }
 
-    // 🔥 Root 역할: PopScope 처리
+    // 🔥 Root 역할: PopScope 처리 (타이머 실행 중 뒤로가기 방지)
     return PopScope(
       canPop: state.timerStatus != TimerStatus.running,
       onPopInvokedWithResult: (didPop, result) {
@@ -422,9 +435,10 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
           // 🔧 실제로 pop이 발생했을 때 화면 비활성 상태 알림
           notifier.setScreenActive(false);
         } else {
-          // pop이 취소되었을 때 - 타이머 실행 중이어서 경고창 표시
+          // 🔧 pop이 취소되었을 때 - 타이머 실행 중이어서 경고창 표시
           _showNavigationWarningDialog(context).then((shouldPop) {
             if (shouldPop && mounted) {
+              // 🔧 사용자가 이동을 확인했을 때만 타이머 종료 후 pop
               notifier.onAction(const GroupDetailAction.stopTimer()).then((_) {
                 if (mounted) {
                   // 🔧 pop 전 화면 비활성 상태 알림
@@ -485,13 +499,13 @@ class _GroupDetailScreenRootState extends ConsumerState<GroupDetailScreenRoot>
             },
           ),
 
-          // 🔧 새로 추가: 스트림 연결 상태 표시 (상단 인디케이터)
+          // 🔧 스트림 연결 상태 표시 (상단 인디케이터)
           if (state.streamConnectionStatus == StreamConnectionStatus.connecting)
             Positioned(
               top: 0,
               left: 0,
               right: 0,
-              child: Container(
+              child: SizedBox(
                 height: 3,
                 child: const LinearProgressIndicator(
                   backgroundColor: Colors.transparent,

--- a/lib/group/presentation/group_detail/group_detail_state.dart
+++ b/lib/group/presentation/group_detail/group_detail_state.dart
@@ -9,7 +9,7 @@ part 'group_detail_state.freezed.dart';
 @freezed
 class GroupDetailState with _$GroupDetailState {
   const GroupDetailState({
-    // 타이머 현재 상태 (단순화된 상태)
+    // 타이머 현재 상태
     this.timerStatus = TimerStatus.stop,
 
     // 현재 타이머 경과 시간 (초)
@@ -21,18 +21,110 @@ class GroupDetailState with _$GroupDetailState {
     // 멤버 목록 (AsyncValue로 감싸진 상태)
     this.groupMembersResult = const AsyncValue.loading(),
 
-    // 에러 메시지 (있는 경우)
+    // 🔧 새로 추가: 실시간 스트림 연결 상태
+    this.streamConnectionStatus = StreamConnectionStatus.connecting,
+
+    // 🔧 새로 추가: 마지막 스트림 업데이트 시간
+    this.lastStreamUpdateTime,
+
+    // 기존 에러 메시지 (단순하게 유지)
     this.errorMessage,
+
+    // 🔧 새로 추가: 재연결 시도 횟수
+    this.reconnectionAttempts = 0,
+
+    // 🔧 새로 추가: 화면 활성 상태
+    this.isScreenActive = true,
+
+    // 🔧 새로 추가: 앱 포그라운드 상태
+    this.isAppInForeground = true,
   });
 
   final TimerStatus timerStatus;
   final int elapsedSeconds;
   final AsyncValue<Group> groupDetailResult;
   final AsyncValue<List<GroupMember>> groupMembersResult;
+
+  // 🔧 새로운 필드들
+  final StreamConnectionStatus streamConnectionStatus;
+  final DateTime? lastStreamUpdateTime;
   final String? errorMessage;
+  final int reconnectionAttempts;
+  final bool isScreenActive;
+  final bool isAppInForeground;
+
+  // 🔧 새로운 헬퍼 메서드들
+
+  /// 실시간 업데이트가 정상적으로 작동하는지 확인
+  bool get isStreamHealthy {
+    if (streamConnectionStatus != StreamConnectionStatus.connected) {
+      return false;
+    }
+
+    if (lastStreamUpdateTime == null) {
+      return false;
+    }
+
+    // 5분 이상 업데이트가 없으면 비정상으로 간주
+    final now = DateTime.now();
+    final timeSinceLastUpdate = now.difference(lastStreamUpdateTime!);
+    return timeSinceLastUpdate.inMinutes < 5;
+  }
+
+  /// 재연결을 시도해야 하는지 확인
+  bool get shouldAttemptReconnection =>
+      streamConnectionStatus == StreamConnectionStatus.disconnected &&
+      reconnectionAttempts < 3 &&
+      isScreenActive &&
+      isAppInForeground;
+
+  /// 사용자에게 표시할 상태 메시지
+  String? get statusMessage {
+    if (!isScreenActive || !isAppInForeground) {
+      return null; // 화면이 비활성 상태일 때는 상태 메시지 표시 안함
+    }
+
+    switch (streamConnectionStatus) {
+      case StreamConnectionStatus.connecting:
+        return '실시간 업데이트 연결 중...';
+
+      case StreamConnectionStatus.connected:
+        if (!isStreamHealthy) {
+          return '실시간 업데이트가 지연되고 있습니다.';
+        }
+        return null; // 정상 상태일 때는 메시지 없음
+
+      case StreamConnectionStatus.disconnected:
+        if (reconnectionAttempts > 0) {
+          return '실시간 업데이트 재연결 중... (${reconnectionAttempts}/3)';
+        }
+        return '실시간 업데이트 연결이 끊어졌습니다.';
+
+      case StreamConnectionStatus.failed:
+        return '실시간 업데이트에 문제가 발생했습니다.';
+    }
+  }
+
+  /// 화면이 활성 상태인지 확인
+  bool get isActive => isScreenActive && isAppInForeground;
 }
 
-// 타이머 상태 열거형 (단순화됨)
+// 🔧 새로운 열거형: 스트림 연결 상태
+enum StreamConnectionStatus {
+  /// 연결 시도 중
+  connecting,
+
+  /// 연결됨 (정상 작동)
+  connected,
+
+  /// 연결 끊어짐 (재연결 시도 가능)
+  disconnected,
+
+  /// 연결 실패 (재연결 불가능한 상태)
+  failed,
+}
+
+// 타이머 상태 열거형 (기존 유지)
 enum TimerStatus {
   running, // 실행 중
   paused, // 일시 정지

--- a/lib/group/presentation/group_detail/group_detail_state.dart
+++ b/lib/group/presentation/group_detail/group_detail_state.dart
@@ -86,22 +86,22 @@ class GroupDetailState with _$GroupDetailState {
 
     switch (streamConnectionStatus) {
       case StreamConnectionStatus.connecting:
-        return '실시간 업데이트 연결 중...';
+        return null; // 🔧 연결 중 메시지 제거 (정상적인 상황)
 
       case StreamConnectionStatus.connected:
         if (!isStreamHealthy) {
-          return '실시간 업데이트가 지연되고 있습니다.';
+          return '실시간 업데이트가 지연되고 있습니다.'; // 🔧 비정상 상황에만 표시
         }
         return null; // 정상 상태일 때는 메시지 없음
 
       case StreamConnectionStatus.disconnected:
         if (reconnectionAttempts > 0) {
-          return '실시간 업데이트 재연결 중... (${reconnectionAttempts}/3)';
+          return '연결 재시도 중... (${reconnectionAttempts}/3)'; // 🔧 재연결 중일 때만 표시
         }
-        return '실시간 업데이트 연결이 끊어졌습니다.';
+        return null; // 🔧 단순 연결 끊어짐은 메시지 제거
 
       case StreamConnectionStatus.failed:
-        return '실시간 업데이트에 문제가 발생했습니다.';
+        return '실시간 업데이트에 문제가 발생했습니다.'; // 🔧 실제 오류 상황
     }
   }
 


### PR DESCRIPTION
## 🚀 주요 변경사항
### 그룹 상세 화면 실시간 업데이트 안정성 강화 
- 실시간 스트림 연결 상태 및 재연결 로직 추가
  - `StreamConnectionStatus` 열거형 (connecting, connected, disconnected, failed) 정의
  - 재연결 시도 횟수(최대 3회) 및 화면 활성 상태에 따른 재연결 로직 구현
  - 스트림 헬스 체크 기능 추가 (2분 주기)
- 화면 및 앱 생명주기 관리 개선
  - `isScreenActive`, `isAppInForeground` 상태 추가 및 Notifier 연동
  - 화면 dispose, 앱 백그라운드 전환 시 Notifier에 상태 알림
  - 앱 재개 시 데이터 갱신 및 상태 복원 로직 개선
- 상태 메시지 시스템 도입
  - 연결 상태, 재연결 시도, 오류 발생 시 사용자에게 스낵바로 피드백 제공
  - 중복 메시지 방지 및 메시지 종류별 스낵바 스타일 차등화
- `GroupDetailNotifier`
  - 의존성 주입 로직 단순화 (중복 초기화 방지 제거)
  - `mounted` 상태를 사용하여 위젯 생명주기와 연동 강화
  - 화면 및 앱 상태 변경에 따른 스트림 구독/해제 로직(`_updateStreamSubscription`) 추가
  - 모든 타이머 및 스트림 정리 로직(`_cleanupAllTimers`) 추가
  - 스트림 데이터 및 에러 처리 로직 분리 및 개선 (`_handleStreamData`, `_handleStreamError`)
- `GroupDetailScreenRoot`
  - 화면 초기화 시 Notifier에 활성 상태 설정
  - 네비게이션 발생 시 Notifier에 비활성 상태 설정
  - `PopScope`의 `onPopInvokedWithResult` 콜백에서 Notifier 상태 업데이트
  - 스트림 연결 중일 때 상단에 `LinearProgressIndicator` 표시


### 그룹 상세 타이머 백그라운드 처리 및 알림 기능 추가 
- 앱 백그라운드 전환 또는 종료 시 실행 중인 타이머를 강제 종료하고 알림 표시
- 타이머 관련 API 호출 시 재시도 로직 추가 (StopTimer)
- 화면 활성/비활성, 앱 포그라운드/백그라운드 상태 관리 로직 개선
- 스트림 연결 상태 및 메시지 표시 로직 수정
- 기타 코드 정리 및 주석 개선

### 백그라운드 타이머 종료 알림 스낵바 복원
- 그룹 상세 화면에서 앱이 백그라운드에 있는 동안 타이머가 종료되었을 경우, 사용자에게 스낵바로 알림을 다시 표시하도록 수정했습니다.
- 기존에 주석 처리되어 있던 관련 로직을 복원했습니다.

## 📷 동작 화면/캡처(옵션)
- (UI 변화, 동작 결과 등을 첨부할 수 있음)

## 💬 참고/이슈 링크(선택)
- 관련 이슈: #(이슈번호)
- 참고사항/의논사항:
