### PR TITLE
fix: 그룹 멤버 변경 감지 및 스트림 처리 개선

### DIFF
--- a/lib/group/module/group_di.dart
+++ b/lib/group/module/group_di.dart
@@ -35,28 +35,43 @@ part 'group_di.g.dart';
 
 // ==================== 그룹 관련 DI ====================
 
-// DataSource 프로바이더 - AppConfig에 따라 Firebase 또는 Mock 구현체 제공
-@Riverpod(keepAlive: true)
+// 🔧 수정: DataSource 프로바이더 - dispose 처리를 위해 keepAlive 제거하고 ref.onDispose 추가
+@riverpod
 GroupDataSource groupDataSource(Ref ref) {
+  GroupDataSource dataSource;
+
   // AppConfig 설정에 따라 Firebase 또는 Mock 구현체 제공
   if (AppConfig.useMockGroup) {
     if (kDebugMode) {
       print('GroupDataSource: MockGroupDataSourceImpl 사용');
     }
-    return MockGroupDataSourceImpl();
+    dataSource = MockGroupDataSourceImpl();
   } else {
     if (kDebugMode) {
       print('GroupDataSource: GroupFirebaseDataSource 사용');
     }
 
     // Firebase 인스턴스들을 주입
-    return GroupFirebaseDataSource(
+    dataSource = GroupFirebaseDataSource(
       firestore: ref.watch(firebaseFirestoreProvider),
-      storage:
-          FirebaseStorage.instance, // FirebaseStorage는 별도 Provider 없이 직접 사용
+      storage: FirebaseStorage.instance,
       auth: ref.watch(firebaseAuthProvider),
     );
   }
+
+  // 🔧 새로 추가: Provider가 dispose될 때 DataSource의 dispose 호출
+  ref.onDispose(() {
+    if (kDebugMode) {
+      print('GroupDataSource Provider: onDispose 호출');
+    }
+
+    // Firebase DataSource인 경우에만 dispose 호출
+    if (dataSource is GroupFirebaseDataSource) {
+      dataSource.dispose();
+    }
+  });
+
+  return dataSource;
 }
 
 // Group chat DataSource


### PR DESCRIPTION
## 🚀 주요 변경사항
- GroupFirebaseDataSource
  - 그룹 멤버 변경을 실시간으로 감지하여 멤버 캐시를 무효화하는 로직 추가
  - `_startMemberChangeDetection`, `_stopMemberChangeDetection` 메서드 추가
  - `dispose` 메서드를 추가하여 스트림 구독 해제
  - `streamGroupMemberTimerStatus` 메서드:
    - 기존 `timerActivities` 컬렉션 스트림만 사용하던 방식에서, `members` 컬렉션 스트림과 `timerActivities` 컬렉션 스트림을 결합하여 멤버 변경에도 반응하도록 수정
    - `StreamController`를 사용하여 두 스트림을 합치고, 어느 한 쪽이라도 변경되면 멤버 목록과 최신 타이머 활동을 다시 조회하여 DTO로 반환
  - 멤버 캐시 무효화 로직에서 멤버 변경 감지 중지 호출 추가
- Group DI
  - `groupDataSource` Provider의 `keepAlive` 속성 제거
  - `ref.onDispose`를 사용하여 Provider가 폐기될 때 `GroupFirebaseDataSource`의 `dispose` 메서드가 호출되도록 수정


## 💬 참고/이슈 링크(선택)
- 관련 이슈: #376 
- 참고사항/의논사항: 멤버 활동이력 컬렉션과 그룹 멤버컬렉션을 동시에 스트림 연결했습니다. (스트림이란 계속 연결 해둔 상태로 변동 사항 있을 때만 읽기 회수 발생)
