### PR TITLE
[fix] 타이머 상태별 배경색상 변경

### DIFF
--- a/lib/group/presentation/group_detail/components/timer_display.dart
+++ b/lib/group/presentation/group_detail/components/timer_display.dart
@@ -89,18 +89,10 @@ class TimerDisplay extends StatelessWidget {
     bool isRunning,
     bool isStopped,
   ) {
-    // 배경색 결정
-    final backgroundColor =
-        isStopped
-            ? const Color(0xFFCDCDFF) // 회색 (정지 상태)
-            : isRunning
-            ? const Color(0xFF8080FF) // 파란색 (실행 중)
-            : const Color(0xFFCDCDFF); // 연한 파란색 (일시 정지)
-
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.only(top: 16, bottom: 24),
-      decoration: BoxDecoration(color: backgroundColor),
+      decoration: BoxDecoration(color: Colors.transparent),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [

--- a/lib/group/presentation/group_detail/group_detail_screen.dart
+++ b/lib/group/presentation/group_detail/group_detail_screen.dart
@@ -149,10 +149,17 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
     final isRunning = timerStatus == TimerStatus.running;
 
     // 상태에 따른 배경색 결정
-    final Color primaryBgColor =
-        isRunning ? const Color(0xFF8080FF) : const Color(0xFFCDCDFF);
-    final Color secondaryBgColor =
-        isRunning ? const Color(0xFF7070EE) : const Color(0xFFE6E6FA);
+    final Color primaryBgColor = switch (timerStatus) {
+      TimerStatus.stop => const Color(0xFF9E9E9E), // 정지 상태 - 회색
+      TimerStatus.running => const Color(0xFF8080FF), // 실행 중 - 파란색
+      _ => const Color(0xFFCDCDFF), // 일시정지 - 연한 파란색
+    };
+
+    final Color secondaryBgColor = switch (timerStatus) {
+      TimerStatus.stop => const Color(0xFF8E8E8E), // 정지 상태 - 진한 회색
+      TimerStatus.running => const Color(0xFF7070EE), // 실행 중 - 진한 파란색
+      _ => const Color(0xFFE6E6FA), // 일시정지 - 연한 보라색
+    };
 
     // 🔥 순수 UI: 멤버 분류 로직
     final activeMembers = members.where((m) => m.isActive).toList();


### PR DESCRIPTION
## 🚀 주요 변경사항
- `timer_display.dart`: TimerDisplay 위젯의 배경색을 투명하게 변경하여 상위 위젯의 배경색이 보이도록 수정
- `group_detail_screen.dart`: 타이머 상태(정지, 실행 중, 일시정지)에 따라 기본 및 보조 배경색을 다르게 적용
    - 정지: 회색 계열
    - 실행 중: 파란색 계열
    - 일시정지: 연한 파란색/보라색 계열


## 💬 참고/이슈 링크(선택)
- 관련 이슈: #368 #387 
