### PR TITLE
[refactor] : 그룹 멤버 데이터 캐싱 로직 제거

### DIFF
--- a/lib/core/utils/time_formatter.dart
+++ b/lib/core/utils/time_formatter.dart
@@ -197,4 +197,26 @@ class TimeFormatter {
   static DateTime getAutoEndTime(DateTime pauseTime) {
     return pauseTime.add(const Duration(microseconds: 1));
   }
+
+  // 요일 숫자를 한글 요일로 변환
+  static String getKoreanWeekday(int weekday) {
+    switch (weekday) {
+      case 1:
+        return '월';
+      case 2:
+        return '화';
+      case 3:
+        return '수';
+      case 4:
+        return '목';
+      case 5:
+        return '금';
+      case 6:
+        return '토';
+      case 7:
+        return '일';
+      default:
+        return '월';
+    }
+  }
 }

--- a/lib/group/data/data_source/group_firebase_data_source.dart
+++ b/lib/group/data/data_source/group_firebase_data_source.dart
@@ -54,7 +54,6 @@ class GroupFirebaseDataSource implements GroupDataSource {
     await _core.joinGroup(groupId);
     // 캐시 무효화
     _query.invalidateJoinedGroupsCache();
-    _query.invalidateGroupMembersCache(groupId);
   }
 
   @override
@@ -62,7 +61,6 @@ class GroupFirebaseDataSource implements GroupDataSource {
     await _core.leaveGroup(groupId);
     // 캐시 무효화
     _query.invalidateJoinedGroupsCache();
-    _query.invalidateGroupMembersCache(groupId);
   }
 
   // ===== Query 기능 위임 =====

--- a/lib/group/data/repository_impl/group_repository_impl.dart
+++ b/lib/group/data/repository_impl/group_repository_impl.dart
@@ -1,7 +1,6 @@
 // lib/group/data/repository_impl/group_repository_impl.dart
 import 'package:devlink_mobile_app/core/result/result.dart';
 import 'package:devlink_mobile_app/core/utils/app_logger.dart';
-import 'package:devlink_mobile_app/core/utils/focus_stats_calculator.dart';
 import 'package:devlink_mobile_app/group/data/data_source/group_data_source.dart';
 import 'package:devlink_mobile_app/group/data/dto/group_dto.dart';
 import 'package:devlink_mobile_app/group/data/dto/group_member_dto.dart';
@@ -14,6 +13,7 @@ import 'package:devlink_mobile_app/group/domain/model/group_member.dart';
 import 'package:devlink_mobile_app/group/domain/model/timer_activity_type.dart';
 import 'package:devlink_mobile_app/group/domain/model/user_streak.dart';
 import 'package:devlink_mobile_app/group/domain/repository/group_repository.dart';
+import 'package:devlink_mobile_app/group/domain/service/focus_stats_calculator.dart';
 
 class GroupRepositoryImpl implements GroupRepository {
   final GroupDataSource _dataSource;

--- a/lib/group/domain/model/group_member.dart
+++ b/lib/group/domain/model/group_member.dart
@@ -1,5 +1,6 @@
 // lib/group/domain/model/group_member.dart
 import 'package:devlink_mobile_app/group/domain/model/timer_activity_type.dart';
+import 'package:devlink_mobile_app/group/domain/service/timer_calculation_service.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'group_member.freezed.dart';
@@ -41,9 +42,7 @@ class GroupMember with _$GroupMember {
   final DateTime? timerPauseExpiryTime;
 
   /// 타이머 상태가 활성화 상태인지 확인
-  bool get isActive =>
-      timerState == TimerActivityType.start ||
-      timerState == TimerActivityType.resume;
+  bool get isActive => TimerCalculationService.isTimerActive(timerState);
 
   /// 타이머 상태가 일시정지 상태인지 확인
   bool get isPaused => timerState == TimerActivityType.pause;
@@ -53,12 +52,14 @@ class GroupMember with _$GroupMember {
 
   /// 현재 경과 시간 계산 (초)
   int get currentElapsedSeconds {
-    if (!isActive || timerStartAt == null) return timerElapsed;
-
-    final now = DateTime.now();
-    return timerElapsed + now.difference(timerStartAt!).inSeconds;
+    return TimerCalculationService.calculateMemberElapsed(this);
   }
 
   /// 현재 경과 시간 계산 (분)
-  int get currentElapsedMinutes => (currentElapsedSeconds / 60).floor();
+  int get currentElapsedMinutes => currentElapsedSeconds ~/ 60;
+
+  /// 현재 경과 시간 (포맷팅된 문자열)
+  String get formattedElapsedTime {
+    return TimerCalculationService.formatMemberElapsedTime(this);
+  }
 }

--- a/lib/group/domain/service/timer_calculation_service.dart
+++ b/lib/group/domain/service/timer_calculation_service.dart
@@ -1,0 +1,106 @@
+// lib/group/domain/service/timer_calculation_service.dart
+import 'package:devlink_mobile_app/core/utils/time_formatter.dart';
+import 'package:devlink_mobile_app/group/domain/model/group_member.dart';
+import 'package:devlink_mobile_app/group/domain/model/timer_activity_type.dart';
+
+/// 타이머 계산 관련 로직을 중앙 집중화하는 서비스 클래스
+class TimerCalculationService {
+  const TimerCalculationService._(); // 인스턴스화 방지
+
+  /// 현재 경과 시간 계산 (초 단위)
+  ///
+  /// [isActive] 타이머 활성 상태
+  /// [startTime] 현재 세션 시작 시간
+  /// [baseElapsed] 기본 누적 시간 (초)
+  /// 반환: 총 경과 시간 (초)
+  static int calculateElapsedSeconds({
+    required bool isActive,
+    required DateTime? startTime,
+    required int baseElapsed,
+  }) {
+    if (!isActive || startTime == null) return baseElapsed;
+
+    // 활성 상태면 기본 누적 시간 + 현재 세션 경과 시간
+    final now = DateTime.now();
+    return baseElapsed + now.difference(startTime).inSeconds;
+  }
+
+  /// 현재 경과 시간 계산 (분 단위)
+  ///
+  /// [isActive] 타이머 활성 상태
+  /// [startTime] 현재 세션 시작 시간
+  /// [baseElapsed] 기본 누적 시간 (초)
+  /// 반환: 총 경과 시간 (분)
+  static int calculateElapsedMinutes({
+    required bool isActive,
+    required DateTime? startTime,
+    required int baseElapsed,
+  }) {
+    final seconds = calculateElapsedSeconds(
+      isActive: isActive,
+      startTime: startTime,
+      baseElapsed: baseElapsed,
+    );
+    return seconds ~/ 60;
+  }
+
+  /// 타이머 상태에 따른 경과 시간 계산
+  ///
+  /// [timerState] 타이머 활동 상태
+  /// [startTime] 현재 세션 시작 시간
+  /// [baseElapsed] 기본 누적 시간 (초)
+  /// 반환: 총 경과 시간 (초)
+  static int calculateElapsedByState({
+    required TimerActivityType timerState,
+    required DateTime? startTime,
+    required int baseElapsed,
+  }) {
+    final isActive =
+        timerState == TimerActivityType.start ||
+        timerState == TimerActivityType.resume;
+
+    return calculateElapsedSeconds(
+      isActive: isActive,
+      startTime: startTime,
+      baseElapsed: baseElapsed,
+    );
+  }
+
+  /// GroupMember 모델에서 경과 시간 계산
+  ///
+  /// [member] 그룹 멤버 모델
+  /// 반환: 총 경과 시간 (초)
+  static int calculateMemberElapsed(GroupMember member) {
+    return calculateElapsedByState(
+      timerState: member.timerState,
+      startTime: member.timerStartAt,
+      baseElapsed: member.timerElapsed,
+    );
+  }
+
+  /// 포맷팅된 시간 문자열 반환
+  ///
+  /// [seconds] 초 단위 시간
+  /// 반환: HH:MM:SS 형식 문자열
+  static String formatElapsedTime(int seconds) {
+    return TimeFormatter.formatSeconds(seconds);
+  }
+
+  /// GroupMember 모델에서 포맷팅된 시간 문자열 반환
+  ///
+  /// [member] 그룹 멤버 모델
+  /// 반환: HH:MM:SS 형식 문자열
+  static String formatMemberElapsedTime(GroupMember member) {
+    final seconds = calculateMemberElapsed(member);
+    return formatElapsedTime(seconds);
+  }
+
+  /// 타이머 상태가 활성 상태인지 확인
+  ///
+  /// [timerState] 타이머 활동 상태
+  /// 반환: 활성 상태 여부
+  static bool isTimerActive(TimerActivityType timerState) {
+    return timerState == TimerActivityType.start ||
+        timerState == TimerActivityType.resume;
+  }
+}

--- a/lib/group/presentation/group_detail/components/member_grid.dart
+++ b/lib/group/presentation/group_detail/components/member_grid.dart
@@ -16,26 +16,26 @@ class MemberGrid extends StatelessWidget {
     required this.onMemberTap,
   });
 
-  // 🔧 통일된 시간 포맷팅 헬퍼 메서드 (timer_display.dart와 동일)
-  String _formatTime(GroupMember member) {
-    int totalSeconds;
-
-    if (member.isActive && member.timerStartAt != null) {
-      // 활성 상태이면 현재 시간 기준으로 경과 시간 계산
-      final now = DateTime.now();
-      totalSeconds = now.difference(member.timerStartAt!).inSeconds;
-    } else {
-      // 비활성 상태이면 저장된 경과 시간 사용
-      totalSeconds = member.timerElapsed;
-    }
-
-    // 🔧 시간 포맷팅 - 항상 HH:MM:SS 형식
-    final hours = totalSeconds ~/ 3600;
-    final minutes = (totalSeconds % 3600) ~/ 60;
-    final seconds = totalSeconds % 60;
-
-    return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
-  }
+  // // 🔧 통일된 시간 포맷팅 헬퍼 메서드 (timer_display.dart와 동일)
+  // String _formatTime(GroupMember member) {
+  //   int totalSeconds;
+  //
+  //   if (member.isActive && member.timerStartAt != null) {
+  //     // 활성 상태이면 현재 시간 기준으로 경과 시간 계산
+  //     final now = DateTime.now();
+  //     totalSeconds = now.difference(member.timerStartAt!).inSeconds;
+  //   } else {
+  //     // 비활성 상태이면 저장된 경과 시간 사용
+  //     totalSeconds = member.timerElapsed;
+  //   }
+  //
+  //   // 🔧 시간 포맷팅 - 항상 HH:MM:SS 형식
+  //   final hours = totalSeconds ~/ 3600;
+  //   final minutes = (totalSeconds % 3600) ~/ 60;
+  //   final seconds = totalSeconds % 60;
+  //
+  //   return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+  // }
 
   @override
   Widget build(BuildContext context) {
@@ -104,7 +104,7 @@ class MemberGrid extends StatelessWidget {
                     MemberTimerItem(
                       imageUrl: member.profileUrl ?? '',
                       isActive: member.isActive,
-                      timeDisplay: _formatTime(member), // 🔧 통일된 포맷 사용
+                      timeDisplay: member.formattedElapsedTime, // 🔧 통일된 포맷 사용
                     ),
 
                     Text(

--- a/lib/group/presentation/group_detail/components/timer_display.dart
+++ b/lib/group/presentation/group_detail/components/timer_display.dart
@@ -1,4 +1,5 @@
 // lib/group/presentation/group_detail/components/timer_display.dart
+import 'package:devlink_mobile_app/core/utils/time_formatter.dart';
 import 'package:devlink_mobile_app/group/presentation/group_detail/group_detail_state.dart';
 import 'package:flutter/material.dart';
 
@@ -17,13 +18,9 @@ class TimerDisplay extends StatelessWidget {
   });
 
   // 🔧 통일된 시간 포맷팅 메서드
+  // _formatTime 메서드 수정
   String _formatTime(int totalSeconds) {
-    final hours = totalSeconds ~/ 3600;
-    final minutes = (totalSeconds % 3600) ~/ 60;
-    final seconds = totalSeconds % 60;
-
-    // 🔧 항상 HH:MM:SS 형식으로 표시
-    return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+    return TimeFormatter.formatSeconds(totalSeconds);
   }
 
   @override

--- a/lib/group/presentation/group_detail/group_detail_screen.dart
+++ b/lib/group/presentation/group_detail/group_detail_screen.dart
@@ -380,28 +380,14 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
   }
 
   // 🔧 개별 멤버 아이템 - 실시간 시간 표시 (수정됨)
+  // _buildMemberItem 메서드 수정
   Widget _buildMemberItem(GroupMember member) {
-    // 🔧 올바른 시간 계산 로직
-    String getTimeDisplay() {
-      int totalSeconds;
-
-      if (member.isActive && member.timerStartAt != null) {
-        // 활성 상태이면 현재 시간 기준으로 경과 시간 계산
-        final now = DateTime.now();
-        totalSeconds = now.difference(member.timerStartAt!).inSeconds;
-        // ❌ member.elapsedSeconds를 더하면 안됨! (중복 계산)
-      } else {
-        // 비활성 상태이면 저장된 경과 시간 사용
-        totalSeconds = member.timerElapsed;
-      }
-
-      // 🔧 시간 포맷팅 - 항상 HH:MM:SS 형식
-      final hours = totalSeconds ~/ 3600;
-      final minutes = (totalSeconds % 3600) ~/ 60;
-      final seconds = totalSeconds % 60;
-
-      return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
-    }
+    // 로그인 사용자인 경우 타이머 시간 직접 사용
+    // final bool isCurrentUser = member.userId == _currentUserId;
+    // final String timeDisplay =
+    //     isCurrentUser
+    //         ? TimeFormatter.formatSeconds(widget.state.elapsedSeconds)
+    //         : member.formattedElapsedTime;
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -464,7 +450,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
         ),
         const SizedBox(height: 8),
 
-        // 🔧 타이머 표시 - 수정된 시간 계산 사용
+        // 타이머 표시 - 모델에서 계산된 시간 사용
         member.isActive
             ? Container(
               padding: const EdgeInsets.symmetric(
@@ -476,7 +462,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
                 borderRadius: BorderRadius.circular(10),
               ),
               child: Text(
-                getTimeDisplay(), // 🔧 수정된 시간 표시
+                member.formattedElapsedTime, // 모델의 메서드 사용
                 style: TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.bold,


### PR DESCRIPTION
## 🚀 주요 변경사항
- GroupQueryFirebase에서 멤버 데이터 캐싱 로직 제거
- 항상 최신 데이터를 Firestore에서 가져오도록 수정
- 타이머 상태 불일치 문제 해결
- 불필요한 캐시 무효화 메서드 제거
- 실시간 스트림과의 일관성 향상

## 💬 참고/이슈 링크(선택)
- 관련 이슈: #337 

